### PR TITLE
OA-56: OMOP Person

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/PersonController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/PersonController.java
@@ -1,0 +1,25 @@
+package org.octri.omop_annotator.controller;
+
+import java.util.Map;
+
+import org.octri.omop_annotator.repository.omop.PersonRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+// TODO: This controller is for demo purposes only.
+@Controller
+@RequestMapping("/data/person")
+public class PersonController {
+
+	@Autowired
+	PersonRepository personRepository;
+
+	@GetMapping("/{id}")
+	public String show(Map<String, Object> model, @PathVariable Long id) {
+		model.put("entity", personRepository.findById(id).get());
+		return "person/show";
+	}	
+}

--- a/src/main/java/org/octri/omop_annotator/domain/omop/Person.java
+++ b/src/main/java/org/octri/omop_annotator/domain/omop/Person.java
@@ -1,0 +1,74 @@
+package org.octri.omop_annotator.domain.omop;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class Person {
+	
+	@Id
+	@Column(name = "person_id")
+	public Long id;
+	
+	@Column(name = "birth_datetime")
+	private Timestamp birthDatetime;
+	
+	@Column(name="gender_source_value")
+	private String gender;
+
+	@Column(name="race_source_value")
+	private String race;
+
+	@Column(name="ethnicity_source_value")
+	private String ethnicity;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Timestamp getBirthDatetime() {
+		return birthDatetime;
+	}
+
+	public void setBirthDatetime(Timestamp birthDatetime) {
+		this.birthDatetime = birthDatetime;
+	}
+
+	public String getGender() {
+		return gender;
+	}
+
+	public void setGender(String gender) {
+		this.gender = gender;
+	}
+
+	public String getRace() {
+		return race;
+	}
+
+	public void setRace(String race) {
+		this.race = race;
+	}
+
+	public String getEthnicity() {
+		return ethnicity;
+	}
+
+	public void setEthnicity(String ethnicity) {
+		this.ethnicity = ethnicity;
+	}
+
+	@Override
+	public String toString() {
+		return "Person [id=" + id + ", birthDatetime=" + birthDatetime + ", gender=" + gender + ", race=" + race
+				+ ", ethnicity=" + ethnicity + "]";
+	}
+
+}

--- a/src/main/java/org/octri/omop_annotator/repository/omop/PersonRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/PersonRepository.java
@@ -1,0 +1,9 @@
+package org.octri.omop_annotator.repository.omop;
+
+import org.octri.omop_annotator.domain.omop.Person;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(path = "person")
+public interface PersonRepository extends PagingAndSortingRepository<Person, Long> {
+}

--- a/src/main/resources/mustache-templates/person/show.mustache
+++ b/src/main/resources/mustache-templates/person/show.mustache
@@ -1,0 +1,28 @@
+<div class="container">
+    <h1>Person</h1>
+    {{>components/messages}}
+    <div>
+        {{#entity}}
+        <h5>Birthdate</h5>
+        <p>
+            {{#birthDatetime}}{{birthDatetime}}{{/birthDatetime}}
+            {{^birthDatetime}}<span class="text-muted">None</span>{{/birthDatetime}}
+        </p>
+        <h5>Gender</h5>
+        <p>
+            {{#gender}}{{gender}}{{/gender}}
+            {{^gender}}<span class="text-muted">None</span>{{/gender}}
+        </p>
+        <h5>Race</h5>
+        <p>
+            {{#race}}{{race}}{{/race}}
+            {{^race}}<span class="text-muted">None</span>{{/race}}
+        </p>
+        <h5>Ethnicity</h5>
+        <p>
+            {{#ethnicity}}{{ethnicity}}{{/ethnicity}}
+            {{^ethnicity}}<span class="text-muted">None</span>{{/ethnicity}}
+        </p>
+        {{/entity}}
+    </div>
+</div>


### PR DESCRIPTION
- Entity and Repository
- Sample controller and view page to exercise db connection

Completing the full mapping of all tables and fields is a little more involved than I realized. "Person" has several other fields that would probably not be used by the app (e.g. concept ids for race, ethnicity, gender) so I went with the bare minimum here as a proof of concept. But I'm wondering if a better approach might be to script some of the entity creation using this csv that details all tables, fields, and keys:

https://github.com/OHDSI/CommonDataModel/blob/master/inst/csv/OMOP_CDMv5.4_Field_Level.csv

Is 5.4 the appropriate version to target?

I also do think it would make sense to create and use a read only repository.