### PR TITLE
OA-78

### DIFF
--- a/src/main/resources/frontend/components/AnnotationLabels.vue
+++ b/src/main/resources/frontend/components/AnnotationLabels.vue
@@ -19,7 +19,7 @@
           </tr>
           <tr v-for="(label, index) in labels" :key="index">
             <td>
-              <input :class="`form-control ${checkInvalid(index, 'displayOrder')}`"
+              <input @change="setValidity(index, 'displayOrder', $event)" class="form-control"
                 type="number"
                 :name="`annotationLabels[${index}].displayOrder`"
                 v-model="labels[index].displayOrder"
@@ -28,15 +28,14 @@
               <div class="invalid-feedback">Value must be present and unique</div>
             </td>
             <td>
-              <input :class="`form-control ${checkInvalid(index, 'displayLabel')}`"
+              <input @change="setValidity(index, 'displayLabel', $event)" class="form-control"
                 :name="`annotationLabels[${index}].displayLabel`"
                 v-model="labels[index].displayLabel"
                 required
               />
-              <div class="invalid-feedback">Value must be present and unique</div>
             </td>
             <td>
-              <input :class="`form-control ${checkInvalid(index, 'outputLabel')}`"
+              <input @change="setValidity(index, 'outputLabel', $event)" class="form-control"
                 :name="`annotationLabels[${index}].outputLabel`"
                 v-model="labels[index].outputLabel"
                 required
@@ -44,7 +43,7 @@
               <div class="invalid-feedback">Value must be present and unique</div>
             </td>
             <td>
-              <input :class="`form-control form-control-color w-100 ${checkInvalid(index, 'accentColor')}`"
+              <input @change="setValidity(index, 'accentColor', $event)" class="form-control form-control-color w-100"
                 type="color"
                 :name="`annotationLabels[${index}].accentColor`"
                 v-model="labels[index].accentColor"
@@ -105,10 +104,16 @@ export default {
     deleteLabel(index) {
       this.labels.splice(index, 1);
     },
-    checkInvalid(index, propName) {
+    setValidity(index, propName, event) {
       const val = this.labels[index][propName];
       const matches = this.labels.filter(label => label[propName] === val);
-      return matches.length > 1 ? "is-invalid": "";
+      if (matches.length > 1) {
+        event.target.classList.add('is-invalid');
+        event.target.setCustomValidity('Invalid');
+      } else {
+        event.target.classList.remove('is-invalid');
+        event.target.setCustomValidity('');
+      }
     }
   },
   computed: {

--- a/src/main/resources/frontend/test/components/AnnotationLabels.spec.js
+++ b/src/main/resources/frontend/test/components/AnnotationLabels.spec.js
@@ -29,4 +29,61 @@ describe('AnnotationLabels.vue', () => {
     expect(wrapper.vm.labels.length).toEqual(1);
     expect(wrapper.vm.labels[0].displayLabel).toEqual('Label 2');
   });
+
+  it('validates displayOrder is unique', async () => {
+    const wrapper = mount(AnnotationLabels);
+    await wrapper.find('.new-entity').trigger('click');
+    let input1 = wrapper.find('input[name="annotationLabels[0].displayOrder"');
+    input1.setValue('1');
+    expect(input1.classes('is-invalid')).toBe(false);
+    await wrapper.find('.new-entity').trigger('click');
+    let input2 = wrapper.find('input[name="annotationLabels[1].displayOrder"');
+    input2.setValue('1');
+    expect(input2.classes('is-invalid')).toBe(true);
+    input2.setValue('2');
+    expect(input2.classes('is-invalid')).toBe(false);
+  });
+
+  it('validates displayLabel is unique', async () => {
+    const wrapper = mount(AnnotationLabels);
+    await wrapper.find('.new-entity').trigger('click');
+    let input1 = wrapper.find('input[name="annotationLabels[0].displayLabel"');
+    input1.setValue('1');
+    expect(input1.classes('is-invalid')).toBe(false);
+    await wrapper.find('.new-entity').trigger('click');
+    let input2 = wrapper.find('input[name="annotationLabels[1].displayLabel"');
+    input2.setValue('1');
+    expect(input2.classes('is-invalid')).toBe(true);
+    input2.setValue('2');
+    expect(input2.classes('is-invalid')).toBe(false);
+  });
+
+  it('validates outputLabel is unique', async () => {
+    const wrapper = mount(AnnotationLabels);
+    await wrapper.find('.new-entity').trigger('click');
+    let input1 = wrapper.find('input[name="annotationLabels[0].outputLabel"');
+    input1.setValue('1');
+    expect(input1.classes('is-invalid')).toBe(false);
+    await wrapper.find('.new-entity').trigger('click');
+    let input2 = wrapper.find('input[name="annotationLabels[1].outputLabel"');
+    input2.setValue('1');
+    expect(input2.classes('is-invalid')).toBe(true);
+    input2.setValue('2');
+    expect(input2.classes('is-invalid')).toBe(false);
+  });
+
+  it('validates accentColor is unique', async () => {
+    const wrapper = mount(AnnotationLabels);
+    await wrapper.find('.new-entity').trigger('click');
+    let input1 = wrapper.find('input[name="annotationLabels[0].accentColor"');
+    input1.setValue('#ffffff');
+    expect(input1.classes('is-invalid')).toBe(false);
+    await wrapper.find('.new-entity').trigger('click');
+    let input2 = wrapper.find('input[name="annotationLabels[1].accentColor"');
+    input2.setValue('#ffffff');
+    expect(input2.classes('is-invalid')).toBe(true);
+    input2.setValue('#000000');
+    expect(input2.classes('is-invalid')).toBe(false);
+  });
+
 });


### PR DESCRIPTION
- Fix validation border on annotation labels
- Make all inputs required
- Add "is-invalid" when field isn't unique for visual cue to user. (Because the submit button is outside the Vue component, it still allows a submission of bad data)

This covers OA-78 and OA-86