### PR TITLE
OA-81 ; add formatting for visit dates

### DIFF
--- a/src/main/java/org/octri/omop_annotator/domain/omop/VisitOccurrence.java
+++ b/src/main/java/org/octri/omop_annotator/domain/omop/VisitOccurrence.java
@@ -1,5 +1,6 @@
 package org.octri.omop_annotator.domain.omop;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import javax.persistence.Column;
@@ -31,20 +32,22 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 public class VisitOccurrence {
-	
+
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
 	@Id
 	@Column(name = "visit_occurrence_id")
 	private Long id;
-	
+
 	@ManyToOne
 	@NotNull
 	@JoinColumn(name = "person_id")
 	Person person;
-	
+
 	@ManyToOne
 	@JoinColumn(name = "visit_concept_id")
 	Concept visitType;
-	
+
 	@Column(name = "visit_start_datetime")
 	@Temporal(TemporalType.TIMESTAMP)
 	private Date visitStart;
@@ -52,7 +55,7 @@ public class VisitOccurrence {
 	@Column(name = "visit_end_datetime")
 	@Temporal(TemporalType.TIMESTAMP)
 	private Date visitEnd;
-	
+
 	@Column(name = "visit_source_value")
 	private String visitSource;
 
@@ -90,12 +93,26 @@ public class VisitOccurrence {
 		return visitStart;
 	}
 
+	public String getFormattedVisitStart() {
+		if (visitStart != null) {
+			return DATE_FORMAT.format(visitStart);
+		}
+		return null;
+	}
+
 	public void setVisitStart(Date visitStart) {
 		this.visitStart = visitStart;
 	}
 
 	public Date getVisitEnd() {
 		return visitEnd;
+	}
+
+	public String getFormattedVisitEnd() {
+		if (visitEnd != null) {
+			return DATE_FORMAT.format(visitEnd);
+		}
+		return null;
 	}
 
 	public void setVisitEnd(Date visitEnd) {

--- a/src/main/resources/frontend/components/VisitList.vue
+++ b/src/main/resources/frontend/components/VisitList.vue
@@ -17,8 +17,8 @@
         </tr>
         <tr v-for="(visit, index) in visits" :key="visit.id">
           <td :data-field="`visitType${index}`">{{ visit.visitType.name }}</td>
-          <td :data-field="`visitStart${index}`">{{ visit.visitStart }}</td>
-          <td :data-field="`visitEnd${index}`">{{ visit.visitEnd }}</td>
+          <td :data-field="`visitStart${index}`">{{ visit.formattedVisitStart }}</td>
+          <td :data-field="`visitEnd${index}`">{{ visit.formattedVisitEnd }}</td>
           <td :data-field="`visitSource${index}`">{{ visit.visitSource }}</td>
           <td :data-field="`admittingSource${index}`">{{ visit.admittingSource }}</td>
           <td :data-field="`dischargedTo${index}`">{{ visit.dischargedTo }}</td>


### PR DESCRIPTION
The Oracle database uses a timestamp data type for these fields. Many of these records do not have the time filled out (defaults to 0:00), but some of them do. There is no indication of the time zone so I did not attempt to output that information.