### PR TITLE
Fix template string for viewing pool topics

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/JudgeController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/JudgeController.java
@@ -40,7 +40,6 @@ public class JudgeController {
 
 	@GetMapping("/pool/{id}")
 	public String showTopicsForPool(Map<String, Object> model, @PathVariable Long id) {
-		
 		SecurityHelper securityHelper = new SecurityHelper(SecurityContextHolder.getContext());
 		
 		model.put("pool", poolRepository.findById(id).get());
@@ -48,7 +47,7 @@ public class JudgeController {
 		model.put("pageWebjars", new String[] { "datatables/js/jquery.dataTables.min.js",
 		"datatables/js/dataTables.bootstrap5.min.js" });
 		model.put("pageScripts", new String[] { "table-sorting.js" });
-		return "/judge/show_topics";		
+		return "judge/show_topics";
 	}
 	
 	@GetMapping("/pool/{poolId}/topic/{topicId}")


### PR DESCRIPTION
In local development, controllers can return both "page" and "/page" to navigate to page.mustache. On dev, however, only "page" works, and the error message is a red herring that seems to be related to authlib interactions:

javax.servlet.ServletException: Cannot expose request attribute 'appVersion' because of an existing model object of the same name
