### PR TITLE
OA-95 ; refactor native database queries

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/PersonController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/PersonController.java
@@ -79,9 +79,7 @@ public class PersonController {
 	@GetMapping(value = "/summary/{personId}/visits", produces = "application/json")
 	@ResponseBody
 	public String getVisits(@PathVariable Long personId) throws JsonProcessingException {
-		// TODO: The following query also works but is (currently) slow.
-		//return mapper.writeValueAsString(visitOccurrenceRepository.findByPersonId(personId));
-		return mapper.writeValueAsString(visitOccurrenceRepository.visitOccurrenceRows(personId));
+		return mapper.writeValueAsString(visitOccurrenceRepository.findByPersonId(personId));
 	}
 
 	@GetMapping(value = "/summary/{personId}/conditions", produces = "application/json")
@@ -90,11 +88,26 @@ public class PersonController {
 		var json = mapper.writeValueAsString(conditionOccurrenceRepository.findByPersonId(personId));
 		return json;
 	}
-	
+
+	@GetMapping(value = "/summary/{personId}/visit/{visitId}/conditions", produces = "application/json")
+	@ResponseBody
+	public String getVisitConditions(@PathVariable Long personId, @PathVariable Long visitId)
+			throws JsonProcessingException {
+		var json = mapper.writeValueAsString(conditionOccurrenceRepository.findByVisitOccurrenceId(visitId));
+		return json;
+	}
+
 	@GetMapping(value = "/summary/{personId}/observations", produces = "application/json")
 	@ResponseBody
 	public String getObservations(@PathVariable Long personId) throws JsonProcessingException {
 		return mapper.writeValueAsString(observationRepository.findByPersonId(personId));
+	}
+
+	@GetMapping(value = "/summary/{personId}/visit/{visitId}/observations", produces = "application/json")
+	@ResponseBody
+	public String getVisitObservations(@PathVariable Long personId, @PathVariable Long visitId)
+			throws JsonProcessingException {
+		return mapper.writeValueAsString(observationRepository.findByVisitOccurrenceId(visitId));
 	}
 
 	@GetMapping(value = "/summary/{personId}/procedures", produces = "application/json")
@@ -103,12 +116,23 @@ public class PersonController {
 		return mapper.writeValueAsString(procedureOccurrenceRepository.findByPersonId(personId));
 	}
 
+	@GetMapping(value = "/summary/{personId}/visit/{visitId}/procedures", produces = "application/json")
+	@ResponseBody
+	public String getVisitProcedures(@PathVariable Long personId, @PathVariable Long visitId)
+			throws JsonProcessingException {
+		return mapper.writeValueAsString(procedureOccurrenceRepository.findByVisitOccurrenceId(visitId));
+	}
+
 	@GetMapping(value = "/summary/{personId}/measurements", produces = "application/json")
 	@ResponseBody
 	public String getMeasurements(@PathVariable Long personId) throws JsonProcessingException {
-		// TODO: Either query is very slow. Even the 'fast' one can take 30 seconds.
-		//return mapper.writeValueAsString(measurementRepository.findByPersonId(personId));
-		return mapper.writeValueAsString(measurementRepository.measurementRows(personId));
+		return mapper.writeValueAsString(measurementRepository.findByPersonId(personId));
 	}
 
+	@GetMapping(value = "/summary/{personId}/visit/{visitId}/measurements", produces = "application/json")
+	@ResponseBody
+	public String getVisitMeasurements(@PathVariable Long personId, @PathVariable Long visitId)
+			throws JsonProcessingException {
+		return mapper.writeValueAsString(measurementRepository.findByVisitOccurrenceId(visitId));
+	}
 }

--- a/src/main/java/org/octri/omop_annotator/domain/omop/ProcedureOccurrence.java
+++ b/src/main/java/org/octri/omop_annotator/domain/omop/ProcedureOccurrence.java
@@ -1,7 +1,6 @@
 package org.octri.omop_annotator.domain.omop;
 
 import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import javax.persistence.Column;
@@ -15,47 +14,47 @@ import javax.validation.constraints.NotNull;
 
 /**
  * OMOP 5.3 Definition of a Procedure Occurrence
- * 
+ *
  * The following columns have been excluded:
- * 	
- * 	procedure_date
- * 	modifier_concept_id
- * 	provider_id
- * 	visit_detail_id - Always 0
- *	procedure_source_value - For example, an ICD10 code, but without the vocabulary so not very useful?
- *	procedure_source_concept_id
- *	modifier_source_value
- * 
+ *
+ * procedure_date
+ * modifier_concept_id
+ * provider_id
+ * visit_detail_id - Always 0
+ * procedure_source_value - For example, an ICD10 code, but without the vocabulary so not very useful?
+ * procedure_source_concept_id
+ * modifier_source_value
+ *
  */
 @Entity
 public class ProcedureOccurrence {
-	
-	@Column(name="procedure_occurrence_id")
+
+	@Column(name = "procedure_occurrence_id")
 	@Id
 	private Long id;
-	
+
 	@ManyToOne
 	@NotNull
-	@JoinColumn(name="person_id")
+	@JoinColumn(name = "person_id")
 	private Person person;
-	
+
 	@ManyToOne
-	@JoinColumn(name="procedure_concept_id")
+	@JoinColumn(name = "procedure_concept_id")
 	private Concept procedure;
-	
-	@Column(name="procedure_datetime")
+
+	@Column(name = "procedure_datetime")
 	@Temporal(TemporalType.TIMESTAMP)
 	private Date procedureDatetime;
-	
+
 	@ManyToOne
-	@JoinColumn(name="procedure_type_concept_id")
+	@JoinColumn(name = "procedure_type_concept_id")
 	private Concept procedureType;
-	
+
 	@ManyToOne
-	@JoinColumn(name="visit_occurrence_id")
+	@JoinColumn(name = "visit_occurrence_id")
 	VisitOccurrence visitOccurrence;
 
-	@Column(name="quantity")
+	@Column(name = "quantity")
 	private BigDecimal quantity;
 
 	public Long getId() {
@@ -120,5 +119,5 @@ public class ProcedureOccurrence {
 				+ ", procedureDatetime=" + procedureDatetime + ", procedureType=" + procedureType + ", visitOccurrence="
 				+ visitOccurrence + ", quantity=" + quantity + "]";
 	}
-	
+
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/ConditionOccurrenceRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/ConditionOccurrenceRepository.java
@@ -4,11 +4,24 @@ import java.util.List;
 
 import org.octri.omop_annotator.domain.omop.ConditionOccurrence;
 import org.octri.omop_annotator.view.ConditionOccurrenceRow;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource(path = "condition_occurrence")
 public interface ConditionOccurrenceRepository extends PagingAndSortingRepository<ConditionOccurrence, Long> {
 
+	static final String query = "select co.id as id, co.person.id as personId, condition.name as condition,"
+			+ " conditionType.name as conditionType, co.conditionStart as conditionStart,"
+			+ " co.conditionEnd as conditionEnd, visitOccurrence.id as visitOccurrence"
+			+ " from ConditionOccurrence co"
+			+ " left join co.condition condition"
+			+ " left join co.conditionType conditionType"
+			+ " left join co.visitOccurrence visitOccurrence";
+
+	@Query(query + " where co.person.id = ?1")
 	List<ConditionOccurrenceRow> findByPersonId(Long personId);
+
+	@Query(query + " where visitOccurrence.id = ?1")
+	List<ConditionOccurrenceRow> findByVisitOccurrenceId(Long visitOccurrenceId);
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/MeasurementRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/MeasurementRepository.java
@@ -11,19 +11,20 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource(path = "measurement")
 public interface MeasurementRepository extends PagingAndSortingRepository<Measurement, Long> {
 
-	static final String measurementQuery = "select measurement_id as id, person_id as person, measurement_datetime as measurementDatetime, measurement_concept.concept_name as measurement, measurement_type_concept.concept_name as measurementType, value_as_number as valueAsNumber, value_concept.concept_name as valueAsConcept, unit_concept.concept_name as unit, visit_occurrence_id as visitOccurrence"
-			+ " from measurement"
-			+ " left join concept measurement_concept on measurement_concept.concept_id = measurement.measurement_concept_id"
-			+ " left join concept measurement_type_concept on measurement_type_concept.concept_id = measurement.measurement_type_concept_id"
-			+ " left join concept value_concept on value_concept.concept_id = measurement.value_as_concept_id"
-			+ " left join concept unit_concept on unit_concept.concept_id = measurement.unit_concept_id"
-			+ " where measurement.person_id = ?1";
-	
-	List<Measurement> findByPersonId(Long id);
-	List<Measurement> findByPersonIdAndVisitOccurrenceId(Long personId, Long visitOccurrenceId);
+	static final String query = "select m.id as id, m.person.id as person, measurementConcept.name as measurement,"
+			+ " measurementTypeConcept.name as measurementType, m.measurementDatetime as measurementDatetime,"
+			+ " m.valueAsNumber as valueAsNumber, valueAsConcept.name as valueAsConcept, unit.name as unit,"
+			+ " visitOccurrence.id as visitOccurrence"
+			+ " from Measurement m"
+			+ " left join m.measurement measurementConcept"
+			+ " left join m.measurementType measurementTypeConcept"
+			+ " left join m.valueAsConcept valueAsConcept"
+			+ " left join m.unit unit"
+			+ " left join m.visitOccurrence visitOccurrence";
 
-	// TODO: OA-95 ; Eliminate native queries for distribution to other organizations.
-	@Query(value = measurementQuery, nativeQuery = true)
-	List<MeasurementRow> measurementRows(Long personId);
+	@Query(query + " where m.person.id = ?1")
+	List<MeasurementRow> findByPersonId(Long id);
 
+	@Query(query + " where visitOccurrence.id = ?1")
+	List<MeasurementRow> findByVisitOccurrenceId(Long visitOccurrenceId);
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/ObservationRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/ObservationRepository.java
@@ -3,13 +3,26 @@ package org.octri.omop_annotator.repository.omop;
 import java.util.List;
 
 import org.octri.omop_annotator.domain.omop.Observation;
+import org.octri.omop_annotator.view.ObservationRow;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource(path = "observation")
 public interface ObservationRepository extends PagingAndSortingRepository<Observation, Long> {
 
-	List<Observation> findByPersonId(Long id);
-	List<Observation> findByPersonIdAndVisitOccurrenceId(Long personId, Long visitOccurrenceId);
+	static final String query = "select obs.id as id, obs.person.id as person, obsConcept.name as name,"
+			+ " obsTypeConcept.name as type, obs.observationDatetime as date, obs.valueAsString as value,"
+			+ " visitOccurrence.id as visitOccurrence"
+			+ " from Observation obs"
+			+ " left join obs.observation obsConcept"
+			+ " left join obs.observationType obsTypeConcept"
+			+ " left join obs.visitOccurrence visitOccurrence";
+
+	@Query(query + " where obs.person.id = ?1")
+	List<ObservationRow> findByPersonId(Long id);
+
+	@Query(query + " where visitOccurrence.id = ?1")
+	List<ObservationRow> findByVisitOccurrenceId(Long visitOccurrenceId);
 
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/ProcedureOccurrenceRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/ProcedureOccurrenceRepository.java
@@ -3,10 +3,26 @@ package org.octri.omop_annotator.repository.omop;
 import java.util.List;
 
 import org.octri.omop_annotator.domain.omop.ProcedureOccurrence;
+import org.octri.omop_annotator.view.ProcedureOccurrenceRow;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource(path = "procedure_occurrence")
 public interface ProcedureOccurrenceRepository extends PagingAndSortingRepository<ProcedureOccurrence, Long> {
-	List<ProcedureOccurrence> findByPersonId(Long id);
+
+	static final String query = "select po.id as id, po.person.id as personId, procedure.name as procedure,"
+			+ " procedureType.name as procedureType, po.procedureDatetime as date, po.quantity as quantity,"
+			+ " visitOccurrence.id as visitOccurrence"
+			+ " from ProcedureOccurrence po"
+			+ " left join po.procedure procedure"
+			+ " left join po.procedureType procedureType"
+			+ " left join po.visitOccurrence visitOccurrence";
+
+	@Query(query + " where po.person.id = ?1")
+	List<ProcedureOccurrenceRow> findByPersonId(Long personId);
+
+	@Query(query + " where visitOccurrence.id = ?1")
+	List<ProcedureOccurrenceRow> findByVisitOccurrenceId(Long visitOccurrenceId);
+
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/VisitOccurrenceRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/VisitOccurrenceRepository.java
@@ -11,16 +11,14 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource(path = "visit_occurrence")
 public interface VisitOccurrenceRepository extends PagingAndSortingRepository<VisitOccurrence, Long> {
 
-	static final String visitOccurrenceQuery = "select visit_occurrence_id as id, person_id as person, visit_concept.concept_name as visitType, visit_start_datetime as visitStart, visit_end_datetime as visitEnd, provider.provider_name as providerName, care_site.care_site_name as careSiteName"
-			+ " from visit_occurrence"
-			+ " left join concept visit_concept on visit_concept.concept_id = visit_occurrence.visit_concept_id"
-			+ " left join provider on provider.provider_id = visit_occurrence.provider_id"
-			+ " left join care_site on care_site.care_site_id = visit_occurrence.care_site_id"
-			+ " where visit_occurrence.person_id = ?1";
+	static final String visitOccurrenceQuery = "select v.id as id, v.person.id as person, visitType.name as visitType,"
+			+ " v.visitStart as visitStart, v.visitEnd as visitEnd, provider.providerName as providerName, careSite.careSiteName as careSiteName"
+			+ " from VisitOccurrence v"
+			+ " left join v.visitType visitType"
+			+ " left join v.provider provider"
+			+ " left join v.careSite careSite"
+			+ " where v.person.id = ?1";
 
-	List<VisitOccurrence> findByPersonId(Long id);
-
-	// TODO: OA-95 ; Eliminate native queries for distribution to other organizations.
-	@Query(value = visitOccurrenceQuery, nativeQuery = true)
-	List<VisitOccurrenceRow> visitOccurrenceRows(Long personId);
+	@Query(value = visitOccurrenceQuery)
+	List<VisitOccurrenceRow> findByPersonId(Long id);
 }

--- a/src/main/java/org/octri/omop_annotator/view/ConditionOccurrenceRow.java
+++ b/src/main/java/org/octri/omop_annotator/view/ConditionOccurrenceRow.java
@@ -2,46 +2,23 @@ package org.octri.omop_annotator.view;
 
 import java.util.Date;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
 /**
- * Projection Interface which defines a row in the ConditionList table (Vue component). This is a closed projection
- * which allows Spring Data JPA to optimize database queries.
- * See: https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#projections
+ * Projection Interface which defines a row in the ConditionList table (Vue component).
  */
 public interface ConditionOccurrenceRow {
 
 	public Long getId();
 
-	@JsonSerialize(using = IdSerializer.class)
-	public IdOnly getPerson();
+	public Long getPersonId();
 
-	@JsonSerialize(using = NameSerializer.class)
-	public NameOnly getCondition();
+	public String getCondition();
 
-	@JsonSerialize(using = NameSerializer.class)
-	public NameOnly getConditionType();
+	public String getConditionType();
 
 	public Date getConditionStart();
 
 	public Date getConditionEnd();
 
-	@JsonSerialize(using = IdSerializer.class)
-	public IdOnly getVisitOccurrence();
+	public Long getVisitOccurrence();
 
-	/**
-	 * Recursive projection for only including the id property.
-	 */
-	interface IdOnly extends Identified {
-
-		public Long getId();
-	}
-
-	/**
-	 * Recursive projection for only including the name property.
-	 */
-	interface NameOnly extends Named {
-
-		public String getName();
-	}
 }

--- a/src/main/java/org/octri/omop_annotator/view/ObservationRow.java
+++ b/src/main/java/org/octri/omop_annotator/view/ObservationRow.java
@@ -1,0 +1,23 @@
+package org.octri.omop_annotator.view;
+
+import java.util.Date;
+
+/**
+ * Row in the Observations table.
+ */
+public interface ObservationRow {
+
+    public Long getId();
+
+    public Long getPerson();
+
+    public String getName();
+
+    public Date getDate();
+
+    public String getType();
+
+    public String getValue();
+
+    public Long getVisitOccurrence();
+}

--- a/src/main/java/org/octri/omop_annotator/view/ProcedureOccurrenceRow.java
+++ b/src/main/java/org/octri/omop_annotator/view/ProcedureOccurrenceRow.java
@@ -1,0 +1,24 @@
+package org.octri.omop_annotator.view;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * Row in the procedures table.
+ */
+public interface ProcedureOccurrenceRow {
+
+    public Long getId();
+
+    public Long getPersonId();
+
+    public String getProcedure();
+
+    public String getProcedureType();
+
+    public Date getDate();
+
+    public BigDecimal getQuantity();
+
+    public Long getVisitOccurrence();
+}

--- a/src/main/resources/frontend/components/ObservationList.vue
+++ b/src/main/resources/frontend/components/ObservationList.vue
@@ -2,7 +2,7 @@
   <div class="observation-list">
     <h2 v-if="showHeader">{{ header }}</h2>
     <div v-if="loading">
-      <LoadingSpinner/>
+      <LoadingSpinner />
     </div>
     <div v-else class="table-responsive">
       <table :id="tableId" class="table table-striped table-bordered sorted">
@@ -22,19 +22,19 @@
               {{ observation.id }}
             </td>
             <td data-field="observation">
-              {{ observation.observation?.name }}
+              {{ observation.name }}
             </td>
             <td data-field="observationDatetime">
-              {{ observation.observationDatetime }}
+              {{ observation.date }}
             </td>
             <td data-field="observationType">
-              {{ observation.observationType?.name }}
+              {{ observation.type }}
             </td>
             <td data-field="valueAsString">
-              {{ observation.valueAsString }}
+              {{ observation.value }}
             </td>
             <td data-field="visitOccurrence">
-              {{ observation.visitOccurrence?.id }}
+              {{ observation.visitOccurrence }}
             </td>
           </tr>
         </tbody>

--- a/src/main/resources/frontend/components/ProcedureList.vue
+++ b/src/main/resources/frontend/components/ProcedureList.vue
@@ -2,7 +2,7 @@
   <div class="procedure-list">
     <h2 v-if="showHeader">{{ header }}</h2>
     <div v-if="loading">
-      <LoadingSpinner/>
+      <LoadingSpinner />
     </div>
     <div v-else class="table-responsive">
       <table :id="tableId" class="table table-striped table-bordered sorted">
@@ -22,19 +22,19 @@
               {{ procedure.id }}
             </td>
             <td data-field="procedure">
-              {{ procedure.procedure?.name }}
+              {{ procedure.procedure }}
             </td>
             <td data-field="procedureDatetime">
-              {{ procedure.procedureDatetime }}
+              {{ procedure.date }}
             </td>
             <td data-field="procedureType">
-              {{ procedure.procedureType?.name }}
+              {{ procedure.procedureType }}
             </td>
             <td data-field="quantity">
               {{ procedure.quantity }}
             </td>
             <td data-field="visitOccurrence">
-              {{ procedure.visitOccurrence?.id }}
+              {{ procedure.visitOccurrence }}
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
# Overview

Refactoring to remove native database queries. Added data endpoints for filtering data tables based on visit.

## Issues

https://octri.ohsu.edu/issues/browse/OA-95

## Discussion

I was disappointed to find out that the closed projections approach outlined in a previous PR does not optimize queries for related entities (https://github.com/spring-projects/spring-data-jpa/issues/1555. This became problematic with the introduction of Providers and Care Sites, which caused many subsequent queries to be performed when retrieving the visit_occurrence data.

For this PR, I re-wrote the native sql queries to use JPQL, which hibernate can then use to create the appropriate SQL depending on the configured data source. This is a tedious approach, but it does guarantee optimal queries. Measurements are still slow, which is not surprising given that we are retrieving 10,000 of them for a single patient. We may want to paginate our queries outside of just using data tables, or not display data for these entities unless it's filtered by a visit.

## Testing
- Configured my environment to log hibernate queries using (`logging.level.org.hibernate.SQL=DEBUG`)
- Hit the json endpoints directly and inspected the logged queries.
- Viewed the patient detail page to confirm that the Vue components still rendered correctly with the same counts.


