### PR TITLE
CIS-1799 Add VS Code Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ bundle-stats.json
 .java-version
 
 # Visual Studio Code
-.vscode
+.vscode/launch.json
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+    "recommendations": [
+        // Spring Boot support
+        "Pivotal.vscode-boot-dev-pack",
+        // Mustache syntax
+        "dawhite.mustache",
+        // Lint JavaScript and Vue files using ESLint
+        "dbaeumer.vscode-eslint",
+        // Formatter for JavaScript and Vue files
+        "esbenp.prettier-vscode",
+        // Vue single file component (SFC) support
+        "johnsoncodehk.volar",
+        // Java language support
+        "vscjava.vscode-java-pack"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "vue"
+    ],
+    "prettier.requireConfig": true,
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
+    },
+    "[vue]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
+    }
+}


### PR DESCRIPTION
# Overview

Add suggested extensions and settings for VS Code.

* Extensions for Java, JavaScript, Vue, and Mustache support
* Settings for linting and formatting JavaScript and Vue files

## Issues

CIS-1792, CIS-1799

## Discussion

- Commits configuration for recommended extensions and settings for JS formatting.
- Includes suggested extensions for Java development, but I'm expecting @lawhead to fill in the Java settings based on his exploration.
- Currently excludes the `.vscode/launch.json` file, because from Matt's demo it seems to get crufty. I don't feel super strongly about it though, and I'm happy to remove it from the `.gitignore` if that's what others want.
