### PR TITLE
OA-108 Temporary Webpack Build Workaround

### DIFF
--- a/src/main/resources/frontend/components/JudgeButton.vue
+++ b/src/main/resources/frontend/components/JudgeButton.vue
@@ -36,20 +36,3 @@ export default {
   }
 };
 </script>
-<style>
-button.annotation-label {
-  filter: opacity(80%);
-  font-size: 0.8rem;
-}
-button.annotation-label:hover,
-button.annotation-label:focus,
-button.annotation-label.active {
-  filter: opacity(100%);
-}
-button.annotation-label:focus {
-  filter: brightness(95%);
-}
-button.annotation-label.active {
-  filter: saturate(120%);
-}
-</style>

--- a/src/main/resources/static/assets/css/main.css
+++ b/src/main/resources/static/assets/css/main.css
@@ -102,3 +102,23 @@ div.parent-summary strong {
 #omop_browser .nav-item {
 	font-size: 0.9rem;
 }
+
+/** JudgeButton component styles **/
+button.annotation-label {
+	filter: opacity(80%);
+	font-size: 0.8rem;
+}
+
+button.annotation-label:hover,
+button.annotation-label:focus,
+button.annotation-label.active {
+	filter: opacity(100%);
+}
+
+button.annotation-label:focus {
+	filter: brightness(95%);
+}
+
+button.annotation-label.active {
+	filter: saturate(120%);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
   entry: {
     'annotation-admin': entrypointPath('annotation-admin.js'),
     'pool-entries': entrypointPath('pool-entries.js'),
-    'person': entrypointPath('person.js'),
+    person: entrypointPath('person.js'),
     'judge-entry': entrypointPath('judge-entry.js') // TODO: temporary entry point for demo.
   },
   resolve: {
@@ -64,6 +64,7 @@ module.exports = {
   },
   devtool: 'cheap-source-map',
   plugins: [
+    new MiniCssExtractPlugin(),
     new VueLoaderPlugin(),
     new webpack.DefinePlugin({
       __VUE_OPTIONS_API__: JSON.stringify(true),


### PR DESCRIPTION
# Overview

To release the changes from sprint 156, temporarily work around Webpack build failure caused by `<style>` block in the `JudgeButton` component by moving styles to `main.css`.

As I suspected in #55, I didn't set up Webpack to extract component styles correctly. It looks like a real fix for this issue will be relatively simple, but I'm taking this approach for now to avoid blocking the release.

## Issues

CIS-1806, OA-108
