### PR TITLE
ESLint Warning: Mutation in Computed Property

### DIFF
--- a/src/main/resources/frontend/components/JudgeEntry.vue
+++ b/src/main/resources/frontend/components/JudgeEntry.vue
@@ -57,12 +57,13 @@ export default {
       return `Judge Entry ${this.poolEntryId}`;
     },
     sortedLabels() {
+      const labels = this.judgment.annotationLabels;
       function compareLabel(a, b) {
         if (a.displayOrder < b.displayOrder) return -1;
         if (a.displayOrder > b.displayOrder) return 1;
         return 0;
       }
-      return this.judgment.annotationLabels.sort(compareLabel);
+      return [...labels].sort(compareLabel);
     }
   },
   methods: {


### PR DESCRIPTION
# Overview

Copy annotation labels before sorting in `JudgeEntry` component's `sortedLabels` property. Fixes ESLint warning about unexpected mutation in computed property.