### PR TITLE
Prevent pool editing once pool entries exist.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/PoolController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/PoolController.java
@@ -4,13 +4,17 @@ import java.util.Map;
 
 import org.octri.omop_annotator.domain.app.Pool;
 import org.octri.omop_annotator.repository.app.AnnotationSchemaRepository;
+import org.octri.omop_annotator.repository.app.PoolEntryRepository;
 import org.octri.omop_annotator.repository.app.PoolRepository;
 import org.octri.omop_annotator.repository.app.TopicSetRepository;
 import org.octri.omop_annotator.view.OptionList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
  * Controller for {@link Pool} objects.
@@ -28,15 +32,25 @@ public class PoolController extends AbstractEntityController<Pool, PoolRepositor
 	@Autowired
 	private TopicSetRepository topicSetRepository;
 
+	@Autowired
+	private PoolEntryRepository poolEntryRepository;
+
+	@Override
+	public String show(Map<String, Object> model, @PathVariable Long id) {
+		String template = super.show(model, id);
+
+		Long numRelatedPoolEntries = poolEntryRepository.countByPoolId(id);
+		model.put("noRelatedPoolEntries", numRelatedPoolEntries == 0);
+		return template;
+	}
+
 	@Override
 	public String newEntity(Map<String, Object> model) {
 		String template = super.newEntity(model);
 
 		// Add options for select.
-		model.put("topicSetOptions",
-				OptionList.fromSearch(topicSetRepository.findAll(), null));
-		model.put("annotationSchemaOptions",
-				OptionList.fromSearch(annotationSchemaRepository.findAll(), null));
+		model.put("topicSetOptions", OptionList.fromSearch(topicSetRepository.findAll(), null));
+		model.put("annotationSchemaOptions", OptionList.fromSearch(annotationSchemaRepository.findAll(), null));
 		return template;
 	}
 
@@ -47,11 +61,23 @@ public class PoolController extends AbstractEntityController<Pool, PoolRepositor
 		Pool entity = (Pool) model.get("entity");
 
 		// Add options for select.
-		model.put("topicSetOptions",
-				OptionList.fromSearch(topicSetRepository.findAll(), entity.getTopicSet()));
+		model.put("topicSetOptions", OptionList.fromSearch(topicSetRepository.findAll(), entity.getTopicSet()));
 		model.put("annotationSchemaOptions",
 				OptionList.fromSearch(annotationSchemaRepository.findAll(), entity.getAnnotationSchema()));
 		return template;
+	}
+
+	@Override
+	public String update(Map<String, Object> model, @PathVariable Long id, @ModelAttribute("entity") Pool entity,
+			BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+		Long numRelatedPoolEntries = poolEntryRepository.countByPoolId(id);
+		if (numRelatedPoolEntries != 0) {
+			redirectAttributes.addFlashAttribute("errorMessage",
+					"This pool has related pool entries and cannot be edited.");
+			return "redirect:/admin/pool/" + id;
+		}
+
+		return super.update(model, id, entity, bindingResult, redirectAttributes);
 	}
 
 	@Override

--- a/src/main/java/org/octri/omop_annotator/repository/app/PoolEntryRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/app/PoolEntryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource(path = "pool_entry")
 public interface PoolEntryRepository extends PagingAndSortingRepository<PoolEntry, Long> {
+	Long countByPoolId(Long id);
 }

--- a/src/main/resources/mustache-templates/pool/show.mustache
+++ b/src/main/resources/mustache-templates/pool/show.mustache
@@ -24,7 +24,12 @@
             {{#comments}}{{.}}{{/comments}}
             {{^comments}}<span class="text-muted">None</span>{{/comments}}
         </p>
-        {{>components/show_links}}
+        <a href="{{req.contextPath}}{{baseRoute}}/" class="btn btn-link"><i class="fas fa-list"></i> List</a>
+        {{#noRelatedPoolEntries}}
+          <a href="{{req.contextPath}}{{baseRoute}}/{{id}}/edit" class="btn btn-link"><i class="fas fa-edit"></i> Edit</a>
+          <a href="{{req.contextPath}}{{baseRoute}}/{{id}}/delete" onclick="return confirm('Delete this item?');"
+             class="btn btn-link text-danger"><i class="fas fa-minus-square"></i> Delete</a>
+        {{/noRelatedPoolEntries}}
         {{/entity}}
     </div>
 </div>


### PR DESCRIPTION
# Overview

Admins can edit a Pool even after Pool Entries and Judgments exist, meaning they can switch the Topic Set or Annotation Schema. Prevent pools from being edited once there is related data.

## Issues

OA-109
