### PR TITLE
OA-102 ; UI improvements

### DIFF
--- a/src/main/java/org/octri/omop_annotator/domain/app/AnnotationLabel.java
+++ b/src/main/java/org/octri/omop_annotator/domain/app/AnnotationLabel.java
@@ -5,9 +5,6 @@ import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-import org.octri.omop_annotator.view.IdSerializer;
 import org.octri.omop_annotator.view.Labelled;
 
 /**
@@ -21,7 +18,6 @@ public class AnnotationLabel extends AbstractEntity implements Labelled {
 
 	@ManyToOne
 	@NotNull
-	@JsonSerialize(using = IdSerializer.class)
 	private AnnotationSchema annotationSchema;
 
 	@NotNull

--- a/src/main/resources/frontend/components/EntryJudgment.vue
+++ b/src/main/resources/frontend/components/EntryJudgment.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="d-flex w-100 justify-content-between align-items-center">
+  <div
+    class="entry-judgment d-flex w-100 justify-content-md-between align-items-md-center flex-wrap"
+  >
     <span>{{ entryJudgment.documentId }}</span>
     <template v-if="isJudged">
       <small v-if="showAnnotation" class="fw-light">{{ entryJudgment.annotation }}</small>

--- a/src/main/resources/frontend/components/JudgmentShell.vue
+++ b/src/main/resources/frontend/components/JudgmentShell.vue
@@ -4,7 +4,7 @@
   </div>
   <div class="row" v-else>
     <div class="col-2">
-      <h2 class="fs-4">Pool Entries</h2>
+      <h2 v-if="showHeader" class="fs-4">Pool Entries</h2>
       <!-- TODO: filter by judged or unjudged -->
       <!-- TODO: pagination or scrolling -->
       <div class="list-group">
@@ -13,6 +13,7 @@
           :key="item.documentId"
           href="#"
           class="list-group-item list-group-item-action"
+          :title="`Show document: ${item.documentId}`"
           :class="{ active: isSelected(item) }"
           :aria-current="isSelected(item)"
           @click.prevent="selectDocument(item)"
@@ -49,6 +50,10 @@ export default {
     topicId: {
       type: Number,
       required: true
+    },
+    showHeader: {
+      type: Boolean,
+      default: true
     }
   },
   inject: {

--- a/src/main/resources/frontend/components/NoteList.vue
+++ b/src/main/resources/frontend/components/NoteList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="note-list">
     <h2 v-if="showHeader">{{ header }}</h2>
-    <div class="table-responsive">
+    <div class="table-responsive omop-data">
       <table class="table table-striped table-bordered table-sm" ref="table">
         <thead>
           <tr>

--- a/src/main/resources/frontend/components/OmopBrowser.vue
+++ b/src/main/resources/frontend/components/OmopBrowser.vue
@@ -1,7 +1,11 @@
 <template>
-  <div class="d-flex justify-content-between align-items-center mb-4">
+  <div class="mb-4">
+    <JudgeEntry
+      :pool-entry-id="poolEntryId"
+      @judgment-saved="handleJudgment"
+      class="mb-2"
+    />
     <PersonSummary :person="person" />
-    <JudgeEntry :pool-entry-id="poolEntryId" @judgment-saved="handleJudgment" />
   </div>
   <h2 class="fs-4">Visits</h2>
   <div class="d-flex justify-content-center" v-if="visitsLoading">

--- a/src/main/resources/frontend/judge.js
+++ b/src/main/resources/frontend/judge.js
@@ -4,10 +4,12 @@ import JudgmentShell from './components/JudgmentShell';
 import injectionKeys from './utils/injection-keys';
 
 const rootNode = document.getElementById('judgment_app');
-const { contextPath, csrfToken, csrfHeader, poolId, topicId } = rootNode.dataset;
+const { contextPath, csrfToken, csrfHeader, poolId, topicId, showHeader } =
+  rootNode.dataset;
 const props = {
   poolId: poolId ? Number.parseInt(poolId) : null,
-  topicId: topicId ? Number.parseInt(topicId) : null
+  topicId: topicId ? Number.parseInt(topicId) : null,
+  showHeader: showHeader ? JSON.parse(showHeader) : null
 };
 
 createApp(JudgmentShell, props)

--- a/src/main/resources/mustache-templates/home.mustache
+++ b/src/main/resources/mustache-templates/home.mustache
@@ -3,8 +3,8 @@
 <div class="container vertical-space">
 	<h1>{{ page_title }}</h1>
 
-	<p>Select a pool to view topics for annotating.</p>
-	
+	<p class="instructions"><i class="fas fa-info-circle"></i> Select a pool to view topics for annotating.</p>
+
     <table class="table table-striped table-bordered sorted">
         <thead>
         <tr>

--- a/src/main/resources/mustache-templates/judge/show_pool_entries.mustache
+++ b/src/main/resources/mustache-templates/judge/show_pool_entries.mustache
@@ -1,23 +1,23 @@
 {{>layout/header}}
 
 <div class="vertical-space">
-	<div class="card mb-4">
-		<div class="card-body">Topic {{#topic}}{{topicNumber}} - {{narrative}}{{/topic}}</div>
-	</div>
 	<nav aria-label="breadcrumb">
 		<ol class="breadcrumb">
 			<li class="breadcrumb-item"><a href="{{req.contextPath}}">Home</a></li>
 			<li class="breadcrumb-item"><a href="{{req.contextPath}}/judge/pool/{{#pool}}{{id}}{{/pool}}">Pool {{#pool}}{{id}}{{/pool}}</a></li>
-			<li class="breadcrumb-item active" aria-current="page">Topic {{#topic}}{{topicNumber}}{{/topic}}</li>
+			<li class="breadcrumb-item active" aria-current="page">Topic {{#topic}}{{topicNumber}}: {{narrative}}{{/topic}}</li>
 		</ol>
 	</nav>
 
-	<div id="judgment_app"
+	<p class="instructions"><i class="fas fa-info-circle"></i> Select a pool entry to view and judge a document.</p>
+	<h2 class="fs-4 mt-2">Pool Entries</h2>
+	<div id="judgment_app" class="mt-2"
 		data-context-path="{{req.contextPath}}"
 		data-csrf-token="{{_csrf.token}}"
 		data-csrf-header="{{_csrf.headerName}}"
 		data-pool-id="{{#pool}}{{id}}{{/pool}}"
 		data-topic-id="{{#topic}}{{id}}{{/topic}}"
+		data-show-header="false"
 	>
 	</div>
 

--- a/src/main/resources/mustache-templates/judge/show_topics.mustache
+++ b/src/main/resources/mustache-templates/judge/show_topics.mustache
@@ -1,35 +1,34 @@
 {{>layout/header}}
 
 <div class="container vertical-space">
-	<h1>{{#pool}}{{name}}{{/pool}}</h1>
 	<nav aria-label="breadcrumb">
 	  <ol class="breadcrumb">
 	    <li class="breadcrumb-item"><a href="{{req.contextPath}}">Home</a></li>
-	    <li class="breadcrumb-item active" aria-current="page">Pool {{#pool}}{{id}}{{/pool}}</li>
+	    <li class="breadcrumb-item active" aria-current="page">Pool {{#pool}}{{id}}: {{name}}{{/pool}}</li>
 	  </ol>
 	</nav>
 
-	<p>Select a topic to begin judging.</p>
-	
-    <table class="table table-striped table-bordered sorted">
-        <thead>
-        <tr>
-            <th>Topic Number</th>
-            <th>Narrative</th>
-            <th>Completed Judgments</th>
-            <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        {{#topicJudgments}}
-        <tr>
-            <td>{{#topicNumber}}{{.}}{{/topicNumber}}</td>
-            <td>{{#narrative}}{{.}}{{/narrative}}</td>
-            <td>{{#completedJudgments}}{{.}}{{/completedJudgments}}/{{#numEntries}}{{.}}{{/numEntries}}</td>
-            <td><a href="{{req.contextPath}}/judge/pool/{{#pool}}{{id}}{{/pool}}/topic/{{#topicId}}{{.}}{{/topicId}}">View</a></td>
-        </tr>
-        {{/topicJudgments}}
-        </tbody>
+	<p class="instructions"><i class="fas fa-info-circle"></i> Select a topic to begin judging.</p>
+
+  <table class="table table-striped table-bordered sorted">
+      <thead>
+      <tr>
+          <th>Topic Number</th>
+          <th>Narrative</th>
+          <th>Completed Judgments</th>
+          <th>Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+      {{#topicJudgments}}
+      <tr>
+          <td>{{#topicNumber}}{{.}}{{/topicNumber}}</td>
+          <td>{{#narrative}}{{.}}{{/narrative}}</td>
+          <td>{{#completedJudgments}}{{.}}{{/completedJudgments}}/{{#numEntries}}{{.}}{{/numEntries}}</td>
+          <td><a href="{{req.contextPath}}/judge/pool/{{#pool}}{{id}}{{/pool}}/topic/{{#topicId}}{{.}}{{/topicId}}">View</a></td>
+      </tr>
+      {{/topicJudgments}}
+      </tbody>
     </table>
 
 </div>

--- a/src/main/resources/mustache-templates/layout/footer.mustache
+++ b/src/main/resources/mustache-templates/layout/footer.mustache
@@ -12,7 +12,7 @@
 			</div>
 		</footer>
 		{{>authlib_fragments/assets}}
-		
+
 		<script type="text/javascript" src="{{req.contextPath}}/webjars/jquery-ui/jquery-ui.min.js"></script>
 		{{#pageWebjars}}
 			{{! Webjars needed by page-specific scripts can be specified in the view model }}
@@ -23,7 +23,7 @@
 		  {{! Page-specific scripts can be specified in the view model }}
 		  <script type="text/javascript" src="{{req.contextPath}}/assets/js/{{.}}"></script>
 		{{/pageScripts}}
-		
+
 		<script type="text/javascript" src="{{req.contextPath}}/webjars/datatables/js/jquery.dataTables.min.js"></script>
 		<script type="text/javascript" src="{{req.contextPath}}/webjars/datatables/js/dataTables.bootstrap5.min.js"></script>
 		<script type="text/javascript" src="{{req.contextPath}}/assets/js/table-sorting.js"></script>

--- a/src/main/resources/mustache-templates/layout/header.mustache
+++ b/src/main/resources/mustache-templates/layout/header.mustache
@@ -6,7 +6,8 @@
 <meta name="ctx" content="{{req.contextPath}}/">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{>authlib_fragments/css}}
-<link rel="stylesheet" href="{{req.contextPath}}/webjars/datatables/css/dataTables.bootstrap5.min.css" />
+<link rel="stylesheet" href="{{req.contextPath}}/webjars/datatables/css/dataTables.bootstrap5.min.css">
+<link rel="stylesheet" href="{{req.contextPath}}/webjars/font-awesome/css/fontawesome.min.css">
 <link rel="stylesheet" href="{{req.contextPath}}/assets/css/datepicker.css">
 <link rel="stylesheet" href="{{req.contextPath}}/assets/css/main.css">
 </head>

--- a/src/main/resources/static/assets/css/main.css
+++ b/src/main/resources/static/assets/css/main.css
@@ -97,6 +97,15 @@ div.parent-summary strong {
 	background-color: rgba(var(--bs-primary-rgb), 0.25);
 }
 
+.instructions {
+	font-weight: lighter;
+	margin-left: 0.5rem;
+}
+
+.instructions i {
+	color: rgb(176, 176, 176);
+}
+
 .omop-data {
 	font-size: 0.9rem;
 }
@@ -105,7 +114,7 @@ div.parent-summary strong {
 	font-size: 0.8rem;
 }
 
-#omop_browser .nav-item {
+#omop_browser .nav-item, .entry-judgment {
 	font-size: 0.9rem;
 }
 


### PR DESCRIPTION
# Overview

UI changes for better wrapping at different screen sizes. Provided consistent navigation and instructions for the Judge interfaces.

## Issues

https://octri.ohsu.edu/issues/browse/OA-102

## Discussion

- Moved breadcrumbs to the top of the pages.
- Removed redundant text
- Decreased font sizes for pool entries
- Added wrapping for judgment result on pool entries
- Moved the Judge control above the person summary.
- Aligned OMOP Browser elements with the Pool Entry list

## Screenshots

Not available due to PHI, but you can pull the changes locally to view.
