### PR TITLE
Lock pool entries from editing once judgments exist.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/repository/app/JudgmentRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/app/JudgmentRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 public interface JudgmentRepository extends PagingAndSortingRepository<Judgment, Long> {
 
     Judgment findByUserIdAndPoolEntryId(Long userId, Long poolEntryId);
+
+	Long countByPoolEntryId(Long id);
 }

--- a/src/main/resources/mustache-templates/pool_entry/show.mustache
+++ b/src/main/resources/mustache-templates/pool_entry/show.mustache
@@ -29,7 +29,12 @@
             {{#frequency}}{{.}}{{/frequency}}
             {{^frequency}}<span class="text-muted">None</span>{{/frequency}}
         </p>
-        {{>components/show_links}}
+        <a href="{{req.contextPath}}{{baseRoute}}/" class="btn btn-link"><i class="fas fa-list"></i> List</a>
+        {{#noRelatedJudgments}}
+          <a href="{{req.contextPath}}{{baseRoute}}/{{id}}/edit" class="btn btn-link"><i class="fas fa-edit"></i> Edit</a>
+          <a href="{{req.contextPath}}{{baseRoute}}/{{id}}/delete" onclick="return confirm('Delete this item?');"
+             class="btn btn-link text-danger"><i class="fas fa-minus-square"></i> Delete</a>
+        {{/noRelatedJudgments}}
         {{/entity}}
     </div>
 </div>


### PR DESCRIPTION
# Overview

Keep pool entries from being editable once they have been judged.

## Issues

OA-112

## Discussion

The application currently allows a pool entry to be edited after a judgment on the entry exists, meaning the admin can change the person that was judged and the topic they were judged on.
