### PR TITLE
OA-105 Visit context

### DIFF
--- a/src/main/resources/frontend/components/VisitList.vue
+++ b/src/main/resources/frontend/components/VisitList.vue
@@ -79,7 +79,7 @@ export default {
   },
   data() {
     return {
-      dataTable: null
+      search: null
     };
   },
   mounted() {
@@ -87,7 +87,7 @@ export default {
   },
   computed: {
     contextAvailable() {
-      return this.selectedVisitId && this.dataTable && this.dataTable.search();
+      return this.selectedVisitId && this.search;
     }
   },
   methods: {
@@ -104,6 +104,10 @@ export default {
           searching: true,
           info: true
         });
+        // Update the component search term when a datatables search is performed.
+        this.dataTable.on('search.dt', () => {
+          this.search = this.dataTable.search();
+        });
       }
     },
     visitIndex(visitId) {
@@ -117,6 +121,8 @@ export default {
       return sortedVisits.findIndex(visit => visit.id === visitId);
     },
     showContext() {
+      // Shows the context in a linear timeline. We may also want the ability to
+      // navigate to the selected record after sorting by a column.
       if (this.contextAvailable) {
         const index = this.visitIndex(this.selectedVisitId);
         const pageLength = this.dataTable.page.len();


### PR DESCRIPTION
# Overview

Added a button to the Visit List component to allow users to see a selected record in the context of all the rows.

## Issues

https://octri.ohsu.edu/issues/browse/OA-105

## Discussion

- The button is only available after users search for a term and select a row, since the data is filtered at that point and context is lost.
- Viewing the context sorts the list by visit start, clears the search term so no filtering occurs, and navigates to the page of the selected element.
- As a followup issue, we may want to have a similar ability to navigate to the selected row after sorting by a column, since the page is reset to the first page.

## Screenshots

None due to PHI.