### PR TITLE
OA-105 ; visit sorting bug fix

### DIFF
--- a/src/main/resources/frontend/components/VisitList.vue
+++ b/src/main/resources/frontend/components/VisitList.vue
@@ -58,6 +58,9 @@
  * Comparison function to compare two visit occurrences by visitStart.
  */
 function compareVisitStart(a, b) {
+  if (a.visitStart === null && b.visitStart === null) return 0;
+  if (a.visitStart === null && b.visitStart !== null) return -1;
+  if (a.visitStart !== null && b.visitStart === null) return 1;
   if (a.visitStart < b.visitStart) return -1;
   if (a.visitStart > b.visitStart) return 1;
   return 0;


### PR DESCRIPTION
# Overview

Fixed a sorting bug which caused differences between browsers.

## Issues

https://octri.ohsu.edu/issues/browse/OA-105

## Discussion

When displaying a record in the context of its surrounding visits, I was first sorting all visits by visitStart. However, this value is allowed to be `null`. In javascript, comparisons of strings with null values produces `false` (`null < "2021-08-25 00:00:00"` and `null > "2021-08-25 00:00:00"`). In the comparator I was using, when both cases were false 0 was returned indicating equivalence. This caused some differences between browsers (maybe different underlying sorting algorithms). 
