### PR TITLE
Renamed VS Code Extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,7 @@
         // Formatter for JavaScript and Vue files
         "esbenp.prettier-vscode",
         // Vue single file component (SFC) support
-        "johnsoncodehk.volar",
+        "Vue.volar",
         // Java language support
         "vscjava.vscode-java-pack"
     ]


### PR DESCRIPTION

# Overview

Update `extensions.json` with the new name of the Volar extension for Vue single file components.
