### PR TITLE
Implement unwrap in custom java descriptor.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/hibernate/NumericFloatJavaDescriptor.java
+++ b/src/main/java/org/octri/omop_annotator/hibernate/NumericFloatJavaDescriptor.java
@@ -3,7 +3,6 @@ package org.octri.omop_annotator.hibernate;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
 import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
@@ -26,9 +25,20 @@ public class NumericFloatJavaDescriptor extends AbstractTypeDescriptor<Float> {
         return Float.valueOf(string);
     }
 
+    @SuppressWarnings({ "unchecked" })
     @Override
     public <X> X unwrap(Float value, Class<X> type, WrapperOptions options) {
-        throw new NotImplementedException("This is a read-only database");
+        if (value == null) {
+            return null;
+        }
+        if (BigDecimal.class.isAssignableFrom(type)) {
+            return (X) BigDecimal.valueOf(value.doubleValue());
+        } else if (BigInteger.class.isAssignableFrom(type)) {
+            return (X) BigInteger.valueOf(value.longValue());
+        } else if (String.class.isAssignableFrom(type)) {
+            return (X) value.toString();
+        }
+        throw unknownUnwrap(type);
     }
 
     @Override
@@ -38,8 +48,7 @@ public class NumericFloatJavaDescriptor extends AbstractTypeDescriptor<Float> {
         }
         if (BigDecimal.class.isInstance(value)) {
             return ((BigDecimal) value).floatValue();
-        }
-        if (BigInteger.class.isInstance(value)) {
+        } else if (BigInteger.class.isInstance(value)) {
             return ((BigInteger) value).floatValue();
         } else if (String.class.isInstance(value)) {
             return Float.valueOf(((String) value));


### PR DESCRIPTION
# Overview

Implement the unwrap method in the custom Java descriptor. It shouldn't be called with a read-only database, but just in case.

## Issues

OA-111

## Discussion

I inserted a debugger and tried to trigger the unwrap method being called on notes. It never was - only the wrap method, so I'm not sure why you had issues with the previous custom descriptor. In any case, it's probably safest to implement both sides of the transformation.