### PR TITLE
OA-108 Configure Webpack CSS Extraction

### DIFF
--- a/src/main/resources/mustache-templates/layout/header.mustache
+++ b/src/main/resources/mustache-templates/layout/header.mustache
@@ -1,15 +1,21 @@
 <!DOCTYPE HTML>
 <html lang="en">
 <head>
-<title>{{displayName}}</title>
-<meta charset="utf-8">
-<meta name="ctx" content="{{req.contextPath}}/">
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{>authlib_fragments/css}}
-<link rel="stylesheet" href="{{req.contextPath}}/webjars/datatables/css/dataTables.bootstrap5.min.css">
-<link rel="stylesheet" href="{{req.contextPath}}/webjars/font-awesome/css/fontawesome.min.css">
-<link rel="stylesheet" href="{{req.contextPath}}/assets/css/datepicker.css">
-<link rel="stylesheet" href="{{req.contextPath}}/assets/css/main.css">
+	<title>{{displayName}}</title>
+	<meta charset="utf-8">
+	<meta name="ctx" content="{{req.contextPath}}/">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+	{{>authlib_fragments/css}}
+	<link rel="stylesheet" href="{{req.contextPath}}/webjars/datatables/css/dataTables.bootstrap5.min.css">
+	<link rel="stylesheet" href="{{req.contextPath}}/webjars/font-awesome/css/fontawesome.min.css">
+	<link rel="stylesheet" href="{{req.contextPath}}/assets/css/datepicker.css">
+	<link rel="stylesheet" href="{{req.contextPath}}/assets/css/main.css">
+
+	{{! Page-specific stylesheets can be specified in the view model }}
+	{{#pageStyles}}
+	<link rel="stylesheet" href="{{req.contextPath}}/assets/css/{{.}}">
+	{{/pageStyles}}
 </head>
 <body>
 	<header>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = {
     'annotation-admin': entrypointPath('annotation-admin.js'),
     judge: entrypointPath('judge.js'),
     person: entrypointPath('person.js'),
-    'judge-entry': entrypointPath('judge-entry.js'), // TODO: temporary entry point for demo.
     'judge-control': entrypointPath('judge-control.js'),
     'pool-entries': entrypointPath('pool-entries.js')
   },
@@ -66,7 +65,9 @@ module.exports = {
   },
   devtool: 'cheap-source-map',
   plugins: [
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin({
+      filename: 'css/[name].css'
+    }),
     new VueLoaderPlugin(),
     new webpack.DefinePlugin({
       __VUE_OPTIONS_API__: JSON.stringify(true),


### PR DESCRIPTION
# Overview

* Configure `MiniCssExtractPlugin` to extract CSS from style tags in Vue SFC files.
* Add code to enable injecting such CSS files into the page header, based on MDCapture.

## Issues

OA-108

## Discussion

With these changes, styles included in a Vue SFC file will be extracted to a CSS file named after the Webpack entrypoint.

For example, a previous iteration of the application included this `<style>` block in the `JudgeButton` component.

```diff
diff --git a/src/main/resources/frontend/components/JudgeButton.vue b/src/main/resources/frontend/components/JudgeButton.vue
index aec486f..b958a24 100644
--- a/src/main/resources/frontend/components/JudgeButton.vue
+++ b/src/main/resources/frontend/components/JudgeButton.vue
@@ -42,3 +42,21 @@ export default {
   }
 };
 </script>
+
+<style>
+button.annotation-label {
+  filter: opacity(80%);
+  font-size: 0.8rem;
+}
+button.annotation-label:hover,
+button.annotation-label:focus,
+button.annotation-label.active {
+  filter: opacity(100%);
+}
+button.annotation-label:focus {
+  filter: brightness(95%);
+}
+button.annotation-label.active {
+  filter: saturate(120%);
+}
+</style>
```

With this `<style>` block, a CSS file with these styles is generated for each entrypoint that uses the `JudgeButton` component.

```
λ tree target/classes/static
target/classes/static
└── assets
    ├── css
    │   ├── datepicker.css
    │   ├── judge-control.css <===
    │   ├── judge.css         <===
    │   ├── main.css
    │   └── person.css        <===
    ├── img
    │   └── OCTRI_logo.png
    └── js
        ├── annotation-admin.js
        ├── datepicker.js
        ├── judge-control.js
        ├── judge.js
        ├── person.js
        ├── pool-entries.js
        ├── table-sorting.js
        ├── validate.js
        └── vendor.js

4 directories, 15 files
```

You then include the styles in the page using the `pageStyles` view model property.

```diff
diff --git a/src/main/java/org/octri/omop_annotator/controller/JudgeController.java b/src/main/java/org/octri/omop_annotator/controller/JudgeController.java
index 8731711..e6253b0 100644
--- a/src/main/java/org/octri/omop_annotator/controller/JudgeController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/JudgeController.java
@@ -54,6 +54,7 @@ public class JudgeController {
 		model.put("pool", poolRepository.findById(poolId).get());
 		model.put("topic", topicRepository.findById(topicId).get());
 		model.put("mainClasses", "container-fluid");
+		model.put("pageStyles", new String[] { "judge.css" });
 		model.put("pageScripts", new String[] { "vendor.js", "judge.js" });
 		return "judge/show_pool_entries";
 	}
```