### PR TITLE
OA-123 ; fixed search bug

### DIFF
--- a/src/main/resources/frontend/components/VisitList.vue
+++ b/src/main/resources/frontend/components/VisitList.vue
@@ -216,6 +216,8 @@ export default {
         if (this.searchEntity === 'visit') {
           // search the datatable
           this.searchResults = null;
+          // clear previous search
+          this.dataTable.column(0).search('');
           this.dataTable.search(this.searchTerm).draw();
         } else if (this.searchTerm.length > 0) {
           // use the API to search the selected child entity


### PR DESCRIPTION
# Overview

Fixed search bug that prevented searching by visit properties after searching by a sub-element.

## Issues

https://octri.ohsu.edu/issues/browse/OA-123

## Discussion

The bug was triggered by searching by any non-visit entity (like 'condition'), which filters results in the visit table, followed by a search within the visit table itself. This was due to a difference in the data tables API calls for visit vs non-visit entities. For non-visit entities, the API returns a list of ids and datatables is searched based on a single column (the id column). Subsequent searches had this column filtering in place, so it needed to be cleared before doing a full text search of the table.
