### PR TITLE
OA-123 search refinement

### DIFF
--- a/src/main/resources/frontend/components/VisitList.vue
+++ b/src/main/resources/frontend/components/VisitList.vue
@@ -220,6 +220,8 @@ export default {
           this.dataTable.column(0).search('');
           this.dataTable.search(this.searchTerm).draw();
         } else if (this.searchTerm.length > 0) {
+          // clear previous visit search
+          this.dataTable.search('');
           // use the API to search the selected child entity
           this.searchResults = await this.omopApi.searchPersonData(
             this.personId,


### PR DESCRIPTION
# Overview

Fix issue when searching visit data followed immediately by a sub-entity search with the same term.

## Issues

https://octri.ohsu.edu/issues/browse/OA-123

## Discussion

Addresses the testing comment. The previous fix cleared visit search results when searching for a sub-entity, but did not address the opposite scenario of clearing sub-entity searches before searching visits.
