### PR TITLE
OA-122: Release to public Github

### DIFF
--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -11,7 +11,7 @@ pipeline {
     GITHUB_PROJECT = 'omop-annotator-release'
     RELEASE_URL = 'https://api.github.com/repos/OCTRI/omop-annotator-release/releases'
     RELEASE_UPLOAD_URL = 'https://uploads.github.com/repos/OCTRI/omop-annotator-release/releases'
-    DELETE_REF_URL = 'https://api.github.com/repos/OCTRI/omop-annotator-release/git/refs'
+    UPDATE_CONTENTS_URL = 'https://api.github.com/repos/OCTRI/omop-annotator-release/contents'
   }
   parameters {
     string(name: 'VERSION', description: 'The version to release.')
@@ -80,21 +80,16 @@ pipeline {
     stage('Create GitHub Release') {
       steps {
         script {
+          // Update metadata in the public Github repo to associate the new tag with a code change
+          sh '''
+          curl -X GET -u ${GITHUB_USER} ${UPDATE_CONTENTS_URL}/metadata.json | jq .sha | sed 's:"::g' > sha.txt
+          echo "{\\"version\\": \\"${VERSION}\\"}" | base64 > metadata.json
+          curl -X PUT -u ${GITHUB_USER} -H 'Accept: application/vnd.github.v3+json' ${UPDATE_CONTENTS_URL}/metadata.json -d "{\\"message\\": \\"Release ${VERSION}\\", \\"content\\":\\"$(cat metadata.json)\\", \\"sha\\": \\"$(cat sha.txt)\\"}"
+          '''
           def releaseName = "OMOP Annotator ${params.VERSION}"
           def zipFileName = "omop_annotator-${params.VERSION}.zip"
           def releaseId = publishGitHubRelease(env.GITHUB_PROJECT, params.VERSION, releaseName, params.DESCRIPTION)
           uploadGitHubReleaseZip(env.GITHUB_PROJECT, releaseId, zipFileName)
-
-          // Delete the tag in the omop-repository-release repo. Nothing has changed there.
-          def deleteTagCurl = """
-          curl \
-            -f \
-            -u '${env.GITHUB_USER}' \
-            -XDELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            ${env.DELETE_REF_URL}/tags/v${params.VERSION}
-          """
-          sh deleteTagCurl
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.octri</groupId>
 	<artifactId>omop_annotator</artifactId>
-	<version>1.0.1-test2</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>omop_annotator</name>


### PR DESCRIPTION
# Overview

The previous pipeline deleted the tag after release since there were no code changes to the public repo. But this caused the release to go back into "Draft" mode and to mark the release date as the last commit on the repo, which was several days ago. This iteration of the pipeline updates a metadata file in the public repository with the latest version number. Then the tag and release can be tied to something.

## Issues

OA-122

## Discussion

- Fix pom version of testing release
- Modify the public repo before tag/release are created so it's tied to a commit