### PR TITLE
OA-94: Fix upload for Windows-style returns.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/service/app/PoolEntryUploadService.java
+++ b/src/main/java/org/octri/omop_annotator/service/app/PoolEntryUploadService.java
@@ -13,9 +13,6 @@ import java.util.stream.Collectors;
 
 import javax.transaction.Transactional;
 
-import com.opencsv.CSVReader;
-import com.opencsv.exceptions.CsvValidationException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.octri.omop_annotator.domain.app.AnnotationSchema;
@@ -31,6 +28,9 @@ import org.octri.omop_annotator.service.omop.PersonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 @Service
 public class PoolEntryUploadService {
@@ -78,6 +78,10 @@ public class PoolEntryUploadService {
 		while ((nextLine = reader.readNext()) != null) {
 			List<String> errors = new ArrayList<>();
 			String topicAsString = nextLine[0];
+			// Skip blank lines. This prevents index out of bounds errors with Windows-style carriage returns.
+			if (StringUtils.isAllBlank(topicAsString)) {
+				continue;
+			}
 			String personAsString = nextLine[1];
 			Optional<Integer> topicNumber = parseInteger(topicAsString);
 			if (topicNumber.isEmpty()) {

--- a/src/main/java/org/octri/omop_annotator/service/app/TopicUploadService.java
+++ b/src/main/java/org/octri/omop_annotator/service/app/TopicUploadService.java
@@ -9,9 +9,6 @@ import java.util.stream.Collectors;
 
 import javax.transaction.Transactional;
 
-import com.opencsv.CSVReader;
-import com.opencsv.exceptions.CsvValidationException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.octri.omop_annotator.domain.app.Topic;
 import org.octri.omop_annotator.domain.app.TopicSet;
@@ -19,6 +16,9 @@ import org.octri.omop_annotator.repository.app.TopicRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 @Service
 public class TopicUploadService {
@@ -52,6 +52,10 @@ public class TopicUploadService {
 		while ((nextLine = reader.readNext()) != null) {
 			List<String> errors = new ArrayList<>();
 			String topicNumberAsString = nextLine[0];
+			// Skip blank lines. This prevents index out of bounds errors with Windows-style carriage returns.
+			if (StringUtils.isAllBlank(topicNumberAsString)) {
+				continue;
+			}
 			String topicNarrative = nextLine[1];
 			Optional<Integer> topicNumber = parseInteger(topicNumberAsString);
 			if (StringUtils.isAllBlank(topicNumberAsString)) {


### PR DESCRIPTION
# Overview

Upload was failing for csv files created in Windows with line ending "\r\n". This is interpreted as 2 line breaks, and throws an "index out of bounds" error. From what I've read, the BufferedReader uses the line separator of the "system", which I took to mean the browser. So I would expect an upload from Citrix to work but not from a Mac. In fact, both threw the error, and when I open them in Excel on both machines, there are line breaks there too:

<img width="1262" alt="Screen Shot 2022-08-23 at 10 45 38 AM" src="https://github.com/user-attachments/assets/6fceeab3-f5e4-48b4-890d-10ac2e7347de">

Skipping blank lines at least works on a Mac, and locally I'm not having other issues with character encoding.

## Issues

OA-94

## Discussion

- Skip blank lines in csv uploads
