### PR TITLE
OA-94: Specify UTF-8 on upload.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.octri</groupId>
 	<artifactId>omop_annotator</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>omop_annotator</name>

--- a/src/main/java/org/octri/omop_annotator/service/app/PoolEntryUploadService.java
+++ b/src/main/java/org/octri/omop_annotator/service/app/PoolEntryUploadService.java
@@ -2,6 +2,7 @@ package org.octri.omop_annotator.service.app;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -70,7 +71,7 @@ public class PoolEntryUploadService {
 
 		List<UploadResult> results = new ArrayList<>();
 		Boolean noErrors = true;
-		CSVReader reader = new CSVReader(new InputStreamReader(multipartFile.getInputStream()));
+		CSVReader reader = new CSVReader(new InputStreamReader(multipartFile.getInputStream(), StandardCharsets.UTF_8));
 		reader.skip(1);
 		Set<Pair<String, String>> topicPersonPairs = new HashSet<>();
 		Map<Integer, Integer> topicNumberSortOrder = new LinkedHashMap<>();

--- a/src/main/java/org/octri/omop_annotator/service/app/TopicUploadService.java
+++ b/src/main/java/org/octri/omop_annotator/service/app/TopicUploadService.java
@@ -2,6 +2,7 @@ package org.octri.omop_annotator.service.app;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,7 +47,7 @@ public class TopicUploadService {
 
 		List<UploadResult> results = new ArrayList<>();
 		Boolean noErrors = true;
-		CSVReader reader = new CSVReader(new InputStreamReader(multipartFile.getInputStream()));
+		CSVReader reader = new CSVReader(new InputStreamReader(multipartFile.getInputStream(), StandardCharsets.UTF_8));
 		reader.skip(1);
 		String[] nextLine;
 		while ((nextLine = reader.readNext()) != null) {


### PR DESCRIPTION
# Overview

The file provided by Steven still has misinterpreted characters when uploaded through our servers. The characters are interpreted correctly in my local instance, so this is a stab in the dark. But maybe if I specify the character set to the input stream reader, it will do the right thing on the servers.

## Issues

OA-94