### PR TITLE
OA-94: Fix blank line check.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/service/app/PoolEntryUploadService.java
+++ b/src/main/java/org/octri/omop_annotator/service/app/PoolEntryUploadService.java
@@ -48,6 +48,10 @@ public class PoolEntryUploadService {
 	@Autowired
 	private PersonService personService;
 
+	private static final int NUM_COLUMNS = 2;
+	private static final int TOPIC_NUMBER_COLUMN = 0;
+	private static final int PERSON_ID_COLUMN = 1;
+
 	/**
 	 * Validate the file and create a new pool and associated pool entries if there are no errors.
 	 *
@@ -78,12 +82,12 @@ public class PoolEntryUploadService {
 		String[] nextLine;
 		while ((nextLine = reader.readNext()) != null) {
 			List<String> errors = new ArrayList<>();
-			String topicAsString = nextLine[0];
+			String topicAsString = nextLine[TOPIC_NUMBER_COLUMN];
 			// Skip blank lines. This prevents index out of bounds errors with Windows-style carriage returns.
-			if (nextLine.length < 2) {
+			if (nextLine.length < NUM_COLUMNS) {
 				continue;
 			}
-			String personAsString = nextLine[1];
+			String personAsString = nextLine[PERSON_ID_COLUMN];
 			Optional<Integer> topicNumber = parseInteger(topicAsString);
 			if (topicNumber.isEmpty()) {
 				errors.add("Topic " + topicAsString + " is not a number");

--- a/src/main/java/org/octri/omop_annotator/service/app/TopicUploadService.java
+++ b/src/main/java/org/octri/omop_annotator/service/app/TopicUploadService.java
@@ -27,6 +27,10 @@ public class TopicUploadService {
 	@Autowired
 	private TopicRepository topicRepository;
 
+	private static final int NUM_COLUMNS = 2;
+	private static final int TOPIC_NUMBER_COLUMN = 0;
+	private static final int TOPIC_NARRATIVE_COLUMN = 1;
+
 	/**
 	 * Validate the file and create topics if there are no errors.
 	 *
@@ -52,12 +56,12 @@ public class TopicUploadService {
 		String[] nextLine;
 		while ((nextLine = reader.readNext()) != null) {
 			List<String> errors = new ArrayList<>();
-			String topicNumberAsString = nextLine[0];
+			String topicNumberAsString = nextLine[TOPIC_NUMBER_COLUMN];
 			// Skip blank lines. This prevents index out of bounds errors with Windows-style carriage returns.
-			if (nextLine.length < 2) {
+			if (nextLine.length < NUM_COLUMNS) {
 				continue;
 			}
-			String topicNarrative = nextLine[1];
+			String topicNarrative = nextLine[TOPIC_NARRATIVE_COLUMN];
 			Optional<Integer> topicNumber = parseInteger(topicNumberAsString);
 			if (StringUtils.isAllBlank(topicNumberAsString)) {
 				errors.add("Topic number cannot be blank");


### PR DESCRIPTION
# Overview

Identify blank lines by checking the array length instead of examining the first column. The first column could be empty for other reasons besides Windows-style breaks.

## Issues

OA-94
