### PR TITLE
Add no-var to ESLint Config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,8 @@ module.exports = {
   rules: {
     eqeqeq: ['error', 'always'],
     'no-console': ['error', { allow: ['warn', 'error'] }],
-    'no-unused-vars': ['error', { vars: 'all', args: 'none' }]
+    'no-unused-vars': ['error', { vars: 'all', args: 'none' }],
+    'no-var': ['error']
   },
   overrides: [
     // node files


### PR DESCRIPTION
# Overview

Add the `no-var` rule to the default ESLint config to encourage using `let` and `const` for variable declarations.
