### PR TITLE
Move fetches to OmopBrowser so list components are presentational only.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/DisplayController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/DisplayController.java
@@ -1,12 +1,9 @@
 package org.octri.omop_annotator.controller;
 
-import java.util.List;
-
 import org.octri.omop_annotator.domain.app.OmopDisplayConfiguration;
 import org.octri.omop_annotator.repository.app.OmopDisplayConfigurationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
- * The ajax call to get display configuration for an entity - this is open to all authenticated users.
+ * The ajax call to get display configuration - this is open to all authenticated users.
  */
 @RestController
 @RequestMapping("/display")
@@ -23,12 +20,11 @@ public class DisplayController {
     @Autowired
     OmopDisplayConfigurationRepository omopDisplayConfigurationRepository;
 
-    @GetMapping(value = "/{entityName}", produces = "application/json")
+    @GetMapping(value = "/")
     @ResponseBody
-    public List<OmopDisplayConfiguration> getDisplayConfiguration(@PathVariable String entityName)
+    public Iterable<OmopDisplayConfiguration> getDisplayConfiguration()
             throws JsonProcessingException {
-        return omopDisplayConfigurationRepository
-                .findAllByEntityName(entityName);
+        return omopDisplayConfigurationRepository.findAll();
     }
 
 }

--- a/src/main/resources/frontend/components/OmopBrowser.vue
+++ b/src/main/resources/frontend/components/OmopBrowser.vue
@@ -135,6 +135,7 @@
             <VisitRelatedList
               v-else
               :items="conditions"
+              :configuration="getConfigurationForEntity('Condition')"
               itemType="Condition"
               :show-header="false"
             />
@@ -268,6 +269,7 @@ export default {
   emits: ['judgment-saved'],
   data() {
     return {
+      configuration: [],
       omopApi: null,
       person: {},
       visits: [],
@@ -286,6 +288,7 @@ export default {
     if (this.omopApi === null) {
       this.omopApi = new OmopApi(this.contextPath);
     }
+    await this.getDisplayConfig();
     await this.loadPerson();
   },
   methods: {
@@ -310,6 +313,16 @@ export default {
       if (window.bootstrap && window.bootstrap.Tab && this.$refs.conditionTab) {
         window.bootstrap.Tab.getOrCreateInstance(this.$refs.conditionTab).show();
       }
+    },
+
+    async getDisplayConfig() {
+      const res = await fetch(`${this.contextPath}/display/`);
+      const finalRes = await res.json();
+      this.configuration = finalRes;
+    },
+
+    getConfigurationForEntity(entityName) {
+      return this.configuration.filter(f => f.entityName === entityName);
     },
 
     async loadPerson() {

--- a/src/main/resources/frontend/components/VisitRelatedList.vue
+++ b/src/main/resources/frontend/components/VisitRelatedList.vue
@@ -34,10 +34,13 @@
 </template>
 
 <script>
-import { contextPath } from '../utils/injection-keys';
 export default {
   props: {
     items: {
+      type: Array,
+      required: true
+    },
+    configuration: {
       type: Array,
       required: true
     },
@@ -66,18 +69,8 @@ export default {
       default: false
     }
   },
-  inject: {
-    [contextPath]: {
-      default: ''
-    }
-  },
-  data() {
-    return {
-      configuration: []
-    };
-  },
   mounted() {
-    this.getDisplayConfig();
+    this.$nextTick(this.drawDataTable);
   },
   computed: {
     header() {
@@ -102,12 +95,6 @@ export default {
     }
   },
   methods: {
-    async getDisplayConfig() {
-      const res = await fetch(`${this.contextPath}/display/${this.itemType}`);
-      const finalRes = await res.json();
-      this.configuration = finalRes;
-      this.$nextTick(this.drawDataTable);
-    },
     drawDataTable() {
       // Format with the datatables library if it is available.
       if (typeof $.fn.DataTable === 'function' && this.$refs.table) {
@@ -153,8 +140,10 @@ export default {
   },
   watch: {
     items() {
-      console.log('Something about items has changed');
-      this.getDisplayConfig();
+      this.$nextTick(this.drawDataTable);
+    },
+    configuration() {
+      this.$nextTick(this.drawDataTable);
     }
   }
 };


### PR DESCRIPTION
# Overview

This moves the fetch of display configuration up a layer in the components so only a single call is necessary and the list components do not require any async fetch logic.

## Issues

OA-146