### PR TITLE
Indexing refinements

### DIFF
--- a/src/main/java/org/octri/omop_annotator/config/SearchIndexingConfig.java
+++ b/src/main/java/org/octri/omop_annotator/config/SearchIndexingConfig.java
@@ -1,0 +1,26 @@
+package org.octri.omop_annotator.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for populating the search index using the Indexer.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "search-indexing")
+public class SearchIndexingConfig {
+
+    // For performance reasons, the Indexer does not index the entire OMOP database. The API requires a list of
+    // personIds to index. If the number of provided ids exceeds what a database allows in a selection list, this value
+    // is used to partition the list of ids into batches that can be run.
+    public Integer batchSize;
+
+    public Integer getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(Integer batchSize) {
+        this.batchSize = batchSize;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,3 +88,4 @@ logging.level.org.hibernate.engine.jdbc.spi.SqlExceptionHelper=off
 # SearchConfig and OmopDataSourceConfiguration for details.
 search.backend-type=lucene
 search.backend-directory-root=search_indices
+search-indexing.batch-size=900


### PR DESCRIPTION
# Overview

Restructured Indexer to chunk indexing into batches of personIds.

## Issues

https://jirabp.ohsu.edu/browse/OA-163

## Discussion

The exception was caused by the code that limits indexing to a given set of person ids. When the list of ids exceeded 1000, Oracle thew an error that it did not support list sizes that large. This PR adds a configuration for the Indexer, since this value is database dependent, and uses the config to partition the list of ids into multiple MassIndexers that are run sequentially.