### PR TITLE
Use OmopEntity enum for display config.

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/OmopDisplayConfigurationController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/OmopDisplayConfigurationController.java
@@ -54,10 +54,10 @@ public class OmopDisplayConfigurationController
 		if (oldConfiguration.isPresent() && oldConfiguration.get().getEditable()) {
 			this.getRepository().save(entity);
 			redirectAttributes.addFlashAttribute("infoMessage",
-					entity.getEntityName() + "." + entity.getFieldName() + " updated.");
+					entity.getEntity().toString() + "." + entity.getFieldName() + " updated.");
 		} else {
 			redirectAttributes.addFlashAttribute("errorMessage",
-					entity.getEntityName() + "." + entity.getFieldName() + " is not editable.");
+					entity.getEntity().toString() + "." + entity.getFieldName() + " is not editable.");
 		}
 		return listingRedirect();
 	}

--- a/src/main/java/org/octri/omop_annotator/domain/app/OmopDisplayConfiguration.java
+++ b/src/main/java/org/octri/omop_annotator/domain/app/OmopDisplayConfiguration.java
@@ -2,6 +2,8 @@ package org.octri.omop_annotator.domain.app;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 /**
  * Configure the displays for the Omop Entities. The fieldName corresponds to the getters
@@ -10,7 +12,9 @@ import javax.persistence.Entity;
 @Entity
 public class OmopDisplayConfiguration extends AbstractEntity {
 
-    private String entityName;
+    @Enumerated(value = EnumType.STRING)
+    private OmopEntity entity;
+
     private String fieldName;
     private String columnDisplay;
 
@@ -28,12 +32,12 @@ public class OmopDisplayConfiguration extends AbstractEntity {
     @Column(columnDefinition = "bit default 1")
     private boolean filterable;
 
-    public String getEntityName() {
-        return entityName;
+    public OmopEntity getEntity() {
+        return entity;
     }
 
-    public void setEntityName(String entityName) {
-        this.entityName = entityName;
+    public void setEntity(OmopEntity entity) {
+        this.entity = entity;
     }
 
     public String getFieldName() {

--- a/src/main/java/org/octri/omop_annotator/repository/app/OmopDisplayConfigurationRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/app/OmopDisplayConfigurationRepository.java
@@ -9,5 +9,4 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource(path = "omop_display_configuration")
 public interface OmopDisplayConfigurationRepository extends PagingAndSortingRepository<OmopDisplayConfiguration, Long> {
 
-    List<OmopDisplayConfiguration> findAllByEntityName(String entityName);
 }

--- a/src/main/resources/db/migration/mysql/V20230320094900__display_config_entity_name.sql
+++ b/src/main/resources/db/migration/mysql/V20230320094900__display_config_entity_name.sql
@@ -1,0 +1,5 @@
+-- Set the entity name to upper case for use with new enumeration
+UPDATE omop_display_configuration SET entity_name = UPPER(entity_name);
+
+-- Change column name for consistency with Pin
+ALTER TABLE omop_display_configuration CHANGE entity_name entity varchar(255);

--- a/src/main/resources/frontend/components/OmopBrowser.vue
+++ b/src/main/resources/frontend/components/OmopBrowser.vue
@@ -17,7 +17,7 @@
       :poolEntryId="this.poolEntryId"
       :visits="visits"
       :pins="pins"
-      :configuration="getConfigurationForEntity('Visit')"
+      :configuration="getConfigurationForEntity('VISIT')"
       :show-header="false"
       :person-id="personId"
       :selected-visit-id="selectedVisitId"
@@ -140,7 +140,7 @@
             <VisitRelatedList
               v-else
               :items="conditions"
-              :configuration="getConfigurationForEntity('Condition')"
+              :configuration="getConfigurationForEntity('CONDITION')"
               itemType="Condition"
               :show-header="false"
             />
@@ -161,7 +161,7 @@
             <VisitRelatedList
               v-else
               :items="observations"
-              :configuration="getConfigurationForEntity('Observation')"
+              :configuration="getConfigurationForEntity('OBSERVATION')"
               itemType="Observation"
               :show-header="false"
             />
@@ -182,7 +182,7 @@
             <VisitRelatedList
               v-else
               :items="procedures"
-              :configuration="getConfigurationForEntity('Procedure')"
+              :configuration="getConfigurationForEntity('PROCEDURE')"
               itemType="Procedure"
               :show-header="false"
             />
@@ -203,7 +203,7 @@
             <GroupedList
               v-else
               :items="measurements"
-              :configuration="getConfigurationForEntity('Measurement')"
+              :configuration="getConfigurationForEntity('MEASUREMENT')"
               itemType="Measurement"
               :show-header="false"
             />
@@ -224,7 +224,7 @@
             <NoteList
               v-else
               :notes="notes"
-              :configuration="getConfigurationForEntity('Note')"
+              :configuration="getConfigurationForEntity('NOTE')"
               :show-header="false"
             />
           </div>
@@ -244,7 +244,7 @@
             <GroupedList
               v-else
               :items="drugs"
-              :configuration="getConfigurationForEntity('Drug')"
+              :configuration="getConfigurationForEntity('DRUG')"
               itemType="Drug"
               :show-header="false"
             />
@@ -365,8 +365,8 @@ export default {
       }
     },
 
-    getConfigurationForEntity(entityName) {
-      return this.configuration.filter(f => f.entityName === entityName);
+    getConfigurationForEntity(entity) {
+      return this.configuration.filter(f => f.entity === entity);
     },
 
     async loadPerson() {


### PR DESCRIPTION
# Overview

Update OmopDisplayConfiguration to use the new OmopEntity enumeration

## Issues

OA-142

## Discussion

I didn't see a way to exploit polymorphism to make this any cleaner. The "OmopEntity" enum is more analogous to the projections than the actual database tables/AbstractEntity objects, and we need the information about type not at the Object level but more when dealing with lists of these Objects even when the list itself is empty.