### PR TITLE
OA-174: Fix display configuration editing

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/OmopDisplayConfigurationController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/OmopDisplayConfigurationController.java
@@ -54,10 +54,10 @@ public class OmopDisplayConfigurationController
 		if (oldConfiguration.isPresent() && oldConfiguration.get().getEditable()) {
 			this.getRepository().save(entity);
 			redirectAttributes.addFlashAttribute("infoMessage",
-					entity.getEntity().toString() + "." + entity.getFieldName() + " updated.");
+					entity.getOmopEntity().toString() + "." + entity.getFieldName() + " updated.");
 		} else {
 			redirectAttributes.addFlashAttribute("errorMessage",
-					entity.getEntity().toString() + "." + entity.getFieldName() + " is not editable.");
+					entity.getOmopEntity().toString() + "." + entity.getFieldName() + " is not editable.");
 		}
 		return listingRedirect();
 	}

--- a/src/main/java/org/octri/omop_annotator/domain/app/OmopDisplayConfiguration.java
+++ b/src/main/java/org/octri/omop_annotator/domain/app/OmopDisplayConfiguration.java
@@ -13,7 +13,8 @@ import javax.persistence.Enumerated;
 public class OmopDisplayConfiguration extends AbstractEntity {
 
     @Enumerated(value = EnumType.STRING)
-    private OmopEntity entity;
+    @Column(name = "entity")
+    private OmopEntity omopEntity;
 
     private String fieldName;
     private String columnDisplay;
@@ -32,12 +33,12 @@ public class OmopDisplayConfiguration extends AbstractEntity {
     @Column(columnDefinition = "bit default 1")
     private boolean filterable;
 
-    public OmopEntity getEntity() {
-        return entity;
+    public OmopEntity getOmopEntity() {
+        return omopEntity;
     }
 
-    public void setEntity(OmopEntity entity) {
-        this.entity = entity;
+    public void setOmopEntity(OmopEntity omopEntity) {
+        this.omopEntity = omopEntity;
     }
 
     public String getFieldName() {

--- a/src/main/resources/mustache-templates/omop_display_configuration/form.mustache
+++ b/src/main/resources/mustache-templates/omop_display_configuration/form.mustache
@@ -1,11 +1,11 @@
 {{>components/form_start}}
 {{#entity}}
-<input type="hidden" name="editable" value="{{entity.editable}}" readonly/>
-<input type="hidden" name="filterable" value="{{entity.filterable}}" readonly/>
+<input type="hidden" name="editable" value="{{editable}}" readonly/>
+<input type="hidden" name="filterable" value="{{filterable}}" readonly/>
 
 <div class="form-group">
-    <label for="entity_name" class="form-label">Entity name</label>
-    <input type="text" class="read-only-form-input form-control" id="entity_name" name="entityName" value="{{#entityName}}{{.}}{{/entityName}}" readonly >
+    <label for="omop_entity" class="form-label">Entity name</label>
+    <input type="text" class="read-only-form-input form-control" id="omop_entity" name="omopEntity" value="{{#omopEntity}}{{.}}{{/omopEntity}}" readonly >
 </div>
 
 <div class="form-group">

--- a/src/main/resources/mustache-templates/omop_display_configuration/list.mustache
+++ b/src/main/resources/mustache-templates/omop_display_configuration/list.mustache
@@ -16,7 +16,7 @@
         <tbody>
         {{#entity_list}}
         <tr>
-            <td>{{#entityName}}{{.}}{{/entityName}}</td>
+            <td>{{#omopEntity}}{{.}}{{/omopEntity}}</td>
             <td>{{#fieldName}}{{.}}{{/fieldName}}</td>
             <td>{{#columnDisplay}}{{.}}{{/columnDisplay}}</td>
             <td>{{#visible}}<span class="fa fa-check text-success"></span>{{/visible}}</td>


### PR DESCRIPTION
# Overview

Editing of display configuration broke when I introduced the OmopEntity enumeration in place of a String.

## Issues

OA-174

## Discussion

- Change the field name from entity to omopEntity, because Mustache gets confused during form submission with a nested field named entity
- Replace references to the old String field entityName