### PR TITLE
OA-174: Fix reference to old field name

### DIFF
--- a/src/main/resources/frontend/components/OmopBrowser.vue
+++ b/src/main/resources/frontend/components/OmopBrowser.vue
@@ -397,8 +397,8 @@ export default {
       }
     },
 
-    getConfigurationForEntity(entity) {
-      return this.configuration.filter(f => f.entity === entity);
+    getConfigurationForEntity(omopEntity) {
+      return this.configuration.filter(f => f.omopEntity === omopEntity);
     },
 
     async loadPerson() {


### PR DESCRIPTION
# Overview

I had to change the name of the field "entity" on OMOP Display Configuration due to Mustache interpretation errors with the field and object name "entity" clashing. I missed changing this reference.

## Issues

OA-174


