### PR TITLE
OA-186 Update Log Dissector for Spring Boot 3

### DIFF
--- a/k8s/dev/deployment.yaml
+++ b/k8s/dev/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         co.elastic.logs/multiline.pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
         co.elastic.logs/multiline.negate: 'true'
         co.elastic.logs/multiline.match: after
-        co.elastic.logs/processors.dissect.tokenizer: '%{+@timestamp} %{+@timestamp->} %{log.level} %{process.pid|long} --- [%{process.thread.name}] %{log.logger} : %{}'
+        co.elastic.logs/processors.dissect.tokenizer: '%{+@timestamp} %{log.level} %{process.pid|long} --- [%{process.thread.name}] %{log.logger} : %{}'
         co.elastic.logs/processors.dissect.ignore_failure: 'true'
         co.elastic.logs/processors.dissect.trim_values: all
         co.elastic.logs/processors.dissect.target_prefix: ''

--- a/k8s/prod/deployment.yaml
+++ b/k8s/prod/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         co.elastic.logs/multiline.pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
         co.elastic.logs/multiline.negate: 'true'
         co.elastic.logs/multiline.match: after
-        co.elastic.logs/processors.dissect.tokenizer: '%{+@timestamp} %{+@timestamp->} %{log.level} %{process.pid|long} --- [%{process.thread.name}] %{log.logger} : %{}'
+        co.elastic.logs/processors.dissect.tokenizer: '%{+@timestamp} %{log.level} %{process.pid|long} --- [%{process.thread.name}] %{log.logger} : %{}'
         co.elastic.logs/processors.dissect.ignore_failure: 'true'
         co.elastic.logs/processors.dissect.trim_values: all
         co.elastic.logs/processors.dissect.target_prefix: ''

--- a/k8s/stage/deployment.yaml
+++ b/k8s/stage/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         co.elastic.logs/multiline.pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
         co.elastic.logs/multiline.negate: 'true'
         co.elastic.logs/multiline.match: after
-        co.elastic.logs/processors.dissect.tokenizer: '%{+@timestamp} %{+@timestamp->} %{log.level} %{process.pid|long} --- [%{process.thread.name}] %{log.logger} : %{}'
+        co.elastic.logs/processors.dissect.tokenizer: '%{+@timestamp} %{log.level} %{process.pid|long} --- [%{process.thread.name}] %{log.logger} : %{}'
         co.elastic.logs/processors.dissect.ignore_failure: 'true'
         co.elastic.logs/processors.dissect.trim_values: all
         co.elastic.logs/processors.dissect.target_prefix: ''


### PR DESCRIPTION
# Overview

Update the log dissector pattern in the deployment manifests for the new format used by Spring Boot 3. Fixes an issue where exceptions were not triggering alerts after the application was upgraded.

## Issues

OA-186
