### PR TITLE
OA-187: Fix Hibernate search query for note text

### DIFF
--- a/src/main/java/org/octri/omop_annotator/repository/omop/VisitOccurrenceRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/VisitOccurrenceRepository.java
@@ -66,7 +66,7 @@ public interface VisitOccurrenceRepository
 	@Query(value = "select distinct note.visitOccurrence.id"
 			+ " from Note note"
 			+ " where note.person.id = ?1"
-			+ " and lower(cast(note.text as string)) like ?2"
+			+ " and note.text like ?2"
 			+ " order by note.visitOccurrence.id asc")
 	List<Integer> findAllByPersonIdAndNoteTextLike(Integer personId, String noteText);
 
@@ -102,7 +102,7 @@ public interface VisitOccurrenceRepository
 			+ " or lower(observation.name) like ?2"
 			+ " or lower(procedure.name) like ?2"
 			+ " or lower(measurement.name) like ?2"
-			+ " or lower(cast(note.text as string)) like ?2"
+			+ " or note.text like ?2"
 			+ " or lower(drug.name) like ?2"
 			+ ")"
 			+ "order by v.id asc";


### PR DESCRIPTION
# Overview

This error was a result of a change I made to fix Hibernate validation errors during the upgrade. Hibernate 6 would no longer validate the call to lower(note.text) in the search query, and I had to add a cast to string to get around it. But when Hibernate constructs the query, it translates that to a cast(note.text as varchar(4000)), and there are many notes larger than that.

In digging through Hibernate search documentation, I found a buried note mentioning that the annotation @FullTextField on the note_text field in the domain object performs some normalization, including lower-casing the field. So lower() in the query is unnecessary. After making the change, I tested search in both PostGres and Oracle, and it is still case-insensitive as desired.

## Issues

OA-187