### PR TITLE
OA-187: Use Hibernate search for notes

### DIFF
--- a/src/main/java/org/octri/omop_annotator/controller/PersonController.java
+++ b/src/main/java/org/octri/omop_annotator/controller/PersonController.java
@@ -110,11 +110,12 @@ public class PersonController {
 		} else if (entity == FilterEntity.measurement) {
 			visitIds = visitOccurrenceService.findAllByPersonIdAndMeasurementNameLike(personId, searchTerm);
 		} else if (entity == FilterEntity.note) {
-			visitIds = visitOccurrenceService.findAllByPersonIdAndNoteTextLike(personId, searchTerm);
+			visitIds = visitOccurrenceService.findAllByPersonIdAndNoteContains(personId, wildcardQueryValue(name));
 		} else if (entity == FilterEntity.medication) {
 			visitIds = visitOccurrenceService.findAllByPersonIdAndDrugNameLike(personId, searchTerm);
 		} else if (entity == FilterEntity.any) {
-			visitIds = visitOccurrenceService.findAllByPersonIdAndAnyEntityContains(personId, name.toLowerCase());
+			visitIds = visitOccurrenceService.findAllByPersonIdAndAnyEntityContains(personId,
+					wildcardQueryValue(searchTerm));
 		}
 		return mapper.writeValueAsString(visitIds);
 	}
@@ -128,6 +129,20 @@ public class PersonController {
 		String prefix = searchTerm.startsWith("%") ? "" : "%";
 		String suffix = searchTerm.endsWith("%") ? "" : "%";
 		return prefix + searchTerm.toLowerCase() + suffix;
+	}
+
+	/**
+	 * Converts a search term that would be used in a SQL Like Query to a wildcard
+	 * used in Hibernate search. The first % is removed if it exists. The last is converted
+	 * to a splat.
+	 * 
+	 * @param searchTerm
+	 * @return
+	 */
+	private String wildcardQueryValue(String searchTerm) {
+		Assert.notNull(searchTerm, "Search term is required");
+		searchTerm = searchTerm.startsWith("%") ? searchTerm.replaceFirst("%", "") : searchTerm;
+		return searchTerm.toLowerCase().replaceAll("%$", "*");
 	}
 
 	@GetMapping(value = "/summary/{personId}/conditions", produces = "application/json")

--- a/src/main/java/org/octri/omop_annotator/repository/omop/CustomVisitOccurrenceRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/CustomVisitOccurrenceRepository.java
@@ -11,5 +11,7 @@ public interface CustomVisitOccurrenceRepository {
 
     public List<VisitOccurrence> search(Integer personId, String term);
 
+    public List<VisitOccurrence> searchNotes(Integer personId, String term);
+
     public List<VisitOccurrence> findAllWithData(Integer personId);
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/CustomVisitOccurrenceRepositoryImpl.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/CustomVisitOccurrenceRepositoryImpl.java
@@ -92,4 +92,18 @@ public class CustomVisitOccurrenceRepositoryImpl implements CustomVisitOccurrenc
                 log.debug("Matched hits: " + hits.size());
                 return hits;
         }
+
+        @Override
+        public List<VisitOccurrence> searchNotes(Integer personId, String term) {
+                log.debug("Running note search for personId: " + personId);
+                SearchSession searchSession = Search.session(entityManager);
+                var result = searchSession.search(VisitOccurrence.class)
+                                .where(f -> f.bool()
+                                                .must(f.match().field("person.id")
+                                                                .matching(personId))
+                                                .must(f.simpleQueryString()
+                                                                .fields("notes.text")
+                                                                .matching(term)));
+                return result.fetchAllHits();
+        }
 }

--- a/src/main/java/org/octri/omop_annotator/repository/omop/VisitOccurrenceRepository.java
+++ b/src/main/java/org/octri/omop_annotator/repository/omop/VisitOccurrenceRepository.java
@@ -63,13 +63,6 @@ public interface VisitOccurrenceRepository
 			+ " order by m.visitOccurrence.id asc")
 	List<Integer> findAllByPersonIdAndMeasurementNameLike(Integer personId, String measurementName);
 
-	@Query(value = "select distinct note.visitOccurrence.id"
-			+ " from Note note"
-			+ " where note.person.id = ?1"
-			+ " and note.text like ?2"
-			+ " order by note.visitOccurrence.id asc")
-	List<Integer> findAllByPersonIdAndNoteTextLike(Integer personId, String noteText);
-
 	@Query(value = "select distinct d.visitOccurrence.id"
 			+ " from DrugExposure d"
 			+ " join d.drug drug"
@@ -78,43 +71,4 @@ public interface VisitOccurrenceRepository
 			+ " order by d.visitOccurrence.id asc")
 	List<Integer> findAllByPersonIdAndDrugNameLike(Integer personId, String drugName);
 
-	static final String fullTextQuery = "select distinct v.id"
-			+ " from VisitOccurrence v"
-			+ " left join v.visitType visitType"
-			+ " left join v.provider provider"
-			+ " left join v.careSite careSite"
-			+ " left join ConditionOccurrence co on co.visitOccurrence.id = v.id"
-			+ " left join co.condition condition"
-			+ " left join Observation obs on obs.visitOccurrence.id = v.id"
-			+ " left join obs.observation observation"
-			+ " left join ProcedureOccurrence po on po.visitOccurrence.id = v.id"
-			+ " left join po.procedure procedure"
-			+ " left join Measurement m on m.visitOccurrence.id = v.id"
-			+ " left join m.measurement measurement"
-			+ " left join Note note on note.visitOccurrence.id = v.id"
-			+ " left join DrugExposure d on d.visitOccurrence.id = v.id"
-			+ " left join d.drug drug"
-			+ " where v.person.id = ?1 and ("
-			+ " lower(provider.providerName) like ?2"
-			+ " or lower(careSite.careSiteName) like ?2"
-			+ " or lower(v.visitSourceValue) like ?2"
-			+ " or lower(condition.name) like ?2"
-			+ " or lower(observation.name) like ?2"
-			+ " or lower(procedure.name) like ?2"
-			+ " or lower(measurement.name) like ?2"
-			+ " or note.text like ?2"
-			+ " or lower(drug.name) like ?2"
-			+ ")"
-			+ "order by v.id asc";
-
-	/**
-	 * Finds all visit ids for a given person where all of the visits either contain the given text or have a child
-	 * entity with the given text.
-	 *
-	 * @param personId
-	 * @param searchTerm
-	 * @return
-	 */
-	@Query(value = fullTextQuery)
-	List<Integer> findAllByPersonIdAndAnyEntityContains(Integer personId, String searchTerm);
 }

--- a/src/main/java/org/octri/omop_annotator/service/omop/VisitOccurrenceService.java
+++ b/src/main/java/org/octri/omop_annotator/service/omop/VisitOccurrenceService.java
@@ -35,8 +35,17 @@ public class VisitOccurrenceService {
 		return repository.findAllByPersonIdAndMeasurementNameLike(personId, measurementName);
 	}
 
-	public List<Integer> findAllByPersonIdAndNoteTextLike(Integer personId, String noteText) {
-		return repository.findAllByPersonIdAndNoteTextLike(personId, noteText);
+	/**
+	 * Perform a text search on notes. This uses Hibernate search instead of a direct query to circumvent Hibernate
+	 * validation errors on text fields not explicitly defined as Clob in Oracle. https://jirabp.ohsu.edu/browse/OA-187
+	 * 
+	 * @param personId
+	 * @param noteText
+	 * @return
+	 */
+	public List<Integer> findAllByPersonIdAndNoteContains(Integer personId, String noteText) {
+		return repository.searchNotes(personId, noteText).stream().map(VisitOccurrence::getId).sorted()
+				.collect(Collectors.toList());
 	}
 
 	public List<Integer> findAllByPersonIdAndDrugNameLike(Integer personId, String drugName) {


### PR DESCRIPTION
# Overview

Previously, Hibernate search was only being used when "Any" was selected from the Visit search box. All other selections directly queried the database, lower-casing the fields of interest and using a like syntax. For example:

```
select * from Measurement
where lower(Measurement.name) like lower(search_term))
```

Due to Hibernate validation errors with note.note_text in Oracle not being explicitly defined as a Clob in Java, we cannot use the call to lower() on note.note_text. Instead, this approach uses Hibernate search where the note is tokenized and lowercased during indexing. Because Hibernate is tokenizing, this does result in slightly different behavior than production. If the note contains the word "Sports", we cannot search for "sport" without adding a wildcard. (This is already true if "Any" is selected.) I've expanded the functionality so that users can also use the "sql like" syntax instead, making it compatible with the behavior on other selections that do direct queries. So a user can search:

```
sport*
%sport%
sports
```
and get all the expected results.

## Issues

OA-187