### PR TITLE
CIS-3116: Adding Tomcat version to address Tomcat CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.7</version>
+		<version>3.2.12</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -24,6 +24,7 @@
 		<node.version>v20.18.0</node.version>
 		<authlib.version>2.1.1</authlib.version>
 		<hibernate.version>6.4.4.Final</hibernate.version>
+		<tomcat.version>10.1.39</tomcat.version>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
# Overview

Added explicit Tomcat version to address Tomcat CVE

## Issues

CIS-3116

## Discussion

- Added Tomcat version `1.1.39` and updated Spring boot 3.2 to latest patch version `3.2.12` in `pom.xml`

## Other

Local build was successful and I could log in
