### PR TITLE
Revert "Test Manual Dispatch for CHANGELOG Action (#185)"

### DIFF
--- a/.github/workflows/dependabot-changelog-update.yaml
+++ b/.github/workflows/dependabot-changelog-update.yaml
@@ -1,15 +1,14 @@
 name: Add Dependabot updates to CHANGELOG.md
 
 on:
-  workflow_dispatch:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - synchronize
-  #     - reopened
-  #     - ready_for_review
-  #     - labeled
-  #     - unlabeled
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
 
 jobs:
   update_changelog:


### PR DESCRIPTION
# Overview

This reverts commit 1130610ccfddde42640dedef0465ebff19e86ce4.

## Issues

N/A

[ ] Added to CHANGELOG.md

## Discussion

Unfortunately, triggering the CHANGELOG update workflow using the `workflow_dispatch` event doesn't work, because the `dangoslen/dependabot-changelog-helper` action depends on properties of the pull request event.