### PR TITLE
CIS-3773 Update build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,5 +25,6 @@ jobs:
   build-container-image:
     name: Build container image
     needs: build-java-source
+    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-image-build.yaml@main
     secrets: inherit

--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -16,9 +16,11 @@ jobs:
     uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-test-build.yaml@main
     with:
       java_version: '17'
+    # Does not inherit secrets due to security changes in automated workflows
 
   run-node-tests:
     name: Run Node.js tests
     uses: OHSU-OCTRI/shared-workflows/.github/workflows/node-test.yaml@main
     with:
       node_version: '24.x'
+    # Does not inherit secrets due to security changes in automated workflows

--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -16,7 +16,6 @@ jobs:
     uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-test-build.yaml@main
     with:
       java_version: '17'
-      publish_to_github_packages: ${{ github.ref == 'refs/heads/main' || github.ref_type == 'tag' }}
 
   run-node-tests:
     name: Run Node.js tests

--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -1,29 +1,25 @@
 ---
-name: Build and publish
+name: Build and test
 on:
   push:
-    branches:
+    branches-ignore:
       - 'main'
+  pull_request:
+    types:
+      - opened
+      - edited
   workflow_dispatch:
 
 jobs:
   build-java-source:
     name: Build jar and test
-    uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-build.yaml@main
+    uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-test-build.yaml@main
     with:
       java_version: '17'
       publish_to_github_packages: ${{ github.ref == 'refs/heads/main' || github.ref_type == 'tag' }}
-    secrets: inherit
 
   run-node-tests:
     name: Run Node.js tests
     uses: OHSU-OCTRI/shared-workflows/.github/workflows/node-test.yaml@main
     with:
       node_version: '24.x'
-    secrets: inherit
-
-  build-container-image:
-    name: Build container image
-    needs: build-java-source
-    uses: OHSU-OCTRI/shared-workflows/.github/workflows/java-image-build.yaml@main
-    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use Node.js 24.x for front end tooling and run `npm audit fix` (OA-195)
 - Use shared GitHub Actions workflows (OA-195)
 - Build container image (OA-195)
+- Create a test build workflow to handle PRs (CIS-3773)
 
 ## [2.0.3] - 2025-09-17
 


### PR DESCRIPTION
# Overview

Split GitHub Actions build workflow, so that the existing workflow only runs on pushes to the "main" branch, while a slimmer "test_build" workflow runs on all other branches as well as opened/edited PRs.

## Issues

[CIS-3773](https://jirabp.ohsu.edu/browse/CIS-3773)

[x] Added to CHANGELOG.md

## Other

For testing, I was planning to trigger each workflow manually, and also recreate a dependabot PR to check which workflow is called.
