### PR TITLE
CIS-3773 Build triggers

### DIFF
--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -4,10 +4,12 @@ on:
   push:
     branches-ignore:
       - 'main'
+      - 'dependabot/**'
   pull_request:
     types:
       - opened
-      - edited # Only catches changes to PR title, body, or base branch
+      - reopened
+      - synchronize
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# Overview

Improve the triggers for test_build.yaml to avoid overlap between push and pull_request events. The overlap previously produced redundant workflow runs on most Dependabot PRs.

Note - this isn't urgent, but I wanted to get the idea out there before I'm out for a while and forget about it.

## Issues

[CIS-3773](https://jirabp.ohsu.edu/browse/CIS-3773)

## Discussion

This solution ignores pushes to dependabot branches, as well as edits to the title/body when the `rebase` or `recreate` commands are used. Dependabot PRs would only trigger the test_build workflow when opened/reopened or when a commit is synchronized to the PR.
